### PR TITLE
Added semver module to prod dependencies for npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18990,8 +18990,7 @@
     "semver": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
-      "dev": true
+      "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
     },
     "semver-compare": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "native-url": "^0.3.4",
     "nedb": "^1.8.0",
     "prismjs": "^1.22.0",
+    "semver": "^7.3.2",
     "serialport": "^9.0.1",
     "serve-favicon": "^2.5.0",
     "socket.io": "^2.3.0",


### PR DESCRIPTION
Fixes `Error: Cannot find module 'semver'` when starting the docker built container.