### PR TITLE
fix: meterType devices missing ccSpecific values

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/zwave-js/zwavejs2mqtt.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/zwave-js/zwavejs2mqtt/alerts/)
 [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/zwave-js/zwavejs2mqtt.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/zwave-js/zwavejs2mqtt/context:javascript)
 
-[![Join channel](https://img.shields.io/badge/SLACK-zwave2mqtt.slack.com-red.svg?style=popout&logo=slack&logoColor=red)](https://join.slack.com/t/zwave2mqtt/shared_invite/enQtNjc4NjgyNjc3NDI2LTc3OGQzYmJlZDIzZTJhMzUzZWQ3M2Q3NThmMjY5MGY1MTc4NjFiOWZhZWE5YjNmNGE0OWRjZjJiMjliZGQyYmU 'Join channel')
+[![Join channel](https://img.shields.io/badge/SLACK-zwave2mqtt.slack.com-red.svg?style=popout&logo=slack&logoColor=red)](https://join.slack.com/t/zwave2mqtt/shared_invite/enQtNjc4NjgyNjc3NDI2LTc3OGQzYmJlZDIzZTJhMzUzZWQ3M2Q3NThmMjY5MGY1MTc4NjFiOWZhZWE5YjNmNGE0OWRjZjJiMjliZGQyYmU "Join channel")
 
-[![Buy Me A Coffee](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/MVg9wc2HE 'Buy Me A Coffee')
+[![Buy Me A Coffee](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/MVg9wc2HE "Buy Me A Coffee")
 
 [![dockeri.co](https://dockeri.co/image/zwavejs/zwavejs2mqtt)](https://hub.docker.com/r/zwavejs/zwavejs2mqtt)
 
@@ -451,11 +451,11 @@ mqtt:
   discovery_prefix: <your_discovery_prefix>
   broker: [YOUR MQTT BROKER] # Remove if you want to use builtin-in MQTT broker
   birth_message:
-    topic: 'homeassistant/status'
-    payload: 'online'
+    topic: "homeassistant/status"
+    payload: "online"
   will_message:
-    topic: 'homeassistant/status'
-    payload: 'offline'
+    topic: "homeassistant/status"
+    payload: "offline"
 ```
 
 Mind you that if you want to use the embedded broker of Home Assistant you

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/zwave-js/zwavejs2mqtt.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/zwave-js/zwavejs2mqtt/alerts/)
 [![Language grade: JavaScript](https://img.shields.io/lgtm/grade/javascript/g/zwave-js/zwavejs2mqtt.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/zwave-js/zwavejs2mqtt/context:javascript)
 
-[![Join channel](https://img.shields.io/badge/SLACK-zwave2mqtt.slack.com-red.svg?style=popout&logo=slack&logoColor=red)](https://join.slack.com/t/zwave2mqtt/shared_invite/enQtNjc4NjgyNjc3NDI2LTc3OGQzYmJlZDIzZTJhMzUzZWQ3M2Q3NThmMjY5MGY1MTc4NjFiOWZhZWE5YjNmNGE0OWRjZjJiMjliZGQyYmU "Join channel")
+[![Join channel](https://img.shields.io/badge/SLACK-zwave2mqtt.slack.com-red.svg?style=popout&logo=slack&logoColor=red)](https://join.slack.com/t/zwave2mqtt/shared_invite/enQtNjc4NjgyNjc3NDI2LTc3OGQzYmJlZDIzZTJhMzUzZWQ3M2Q3NThmMjY5MGY1MTc4NjFiOWZhZWE5YjNmNGE0OWRjZjJiMjliZGQyYmU 'Join channel')
 
-[![Buy Me A Coffee](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/MVg9wc2HE "Buy Me A Coffee")
+[![Buy Me A Coffee](https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png)](https://www.buymeacoffee.com/MVg9wc2HE 'Buy Me A Coffee')
 
 [![dockeri.co](https://dockeri.co/image/zwavejs/zwavejs2mqtt)](https://hub.docker.com/r/zwavejs/zwavejs2mqtt)
 
@@ -451,11 +451,11 @@ mqtt:
   discovery_prefix: <your_discovery_prefix>
   broker: [YOUR MQTT BROKER] # Remove if you want to use builtin-in MQTT broker
   birth_message:
-    topic: "homeassistant/status"
-    payload: "online"
+    topic: 'homeassistant/status'
+    payload: 'online'
   will_message:
-    topic: "homeassistant/status"
-    payload: "offline"
+    topic: 'homeassistant/status'
+    payload: 'offline'
 ```
 
 Mind you that if you want to use the embedded broker of Home Assistant you

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -1321,7 +1321,11 @@ Gateway.prototype.discoverValue = function (node, vId) {
         } else if (cmdClass === CommandClasses.Meter) {
           // https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/commandclass/MeterCC.ts
           // https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/meters.json
-          sensor = Constants.meterType(valueId.ccSpecific.meterType)
+          if (valueId.ccSpecific) {
+            sensor = Constants.meterType(valueId.ccSpecific.meterType)
+          } else {
+            return
+          }
         } else if (cmdClass === CommandClasses['Pulse Meter']) {
           sensor = {
             sensor: 'pulse',

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -1317,12 +1317,18 @@ Gateway.prototype.discoverValue = function (node, vId) {
         // https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/commandclass/MultilevelSensorCC.ts
         if (cmdClass === CommandClasses['Multilevel Sensor']) {
           // https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/sensorTypes.json
-          sensor = Constants.sensorType(valueId.ccSpecific.sensorType)
+          // In some cases Multilevel Sensors offer Reset option or DeltaTime sensors, but do not include ccSpecific
+          // information. With this change, we target only the sensors and not the additional Properties.
+          if (valueId.ccSpecific) {
+            sensor = Constants.sensorType(valueId.ccSpecific.sensorType)
+          } else {
+            return
+          }
         } else if (cmdClass === CommandClasses.Meter) {
           // https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/commandclass/MeterCC.ts
           // https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/meters.json
           // In some cases Metering devices offer Reset option or DeltaTime sensors, but do not include ccSpecific
-          // information. With this change, we target only the sensors and not the additional Proeprties.
+          // information. With this change, we target only the sensors and not the additional Properties.
           if (valueId.ccSpecific) {
             sensor = Constants.meterType(valueId.ccSpecific.meterType)
           } else {

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -1321,6 +1321,8 @@ Gateway.prototype.discoverValue = function (node, vId) {
         } else if (cmdClass === CommandClasses.Meter) {
           // https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/commandclass/MeterCC.ts
           // https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/meters.json
+          // In some cases Metering devices offer Reset option or DeltaTime sensors, but do not include ccSpecific
+          // information. With this change, we target only the sensors and not the additional Proeprties.
           if (valueId.ccSpecific) {
             sensor = Constants.meterType(valueId.ccSpecific.meterType)
           } else {


### PR DESCRIPTION
When a Command Class is type Meter. In some cases is not a sensor. This metric is a Delta in time, or reset parameter for the Sensor.
There Parameters miss the ccSpecific values, which sets the type of sensor. This change fixes this error