### PR TITLE
Feature: Add Export button to Nodes for Debug reasons

### DIFF
--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -142,10 +142,6 @@
                       @click:append-outer="sendNodeAction"
                     ></v-select>
                   </v-flex>
-                  <v-btn color="green darken-1" text @click="exportNode">
-                    Export
-                    <v-icon right dark>file_download</v-icon>
-                  </v-btn>
                 </v-layout>
 
                 <v-layout row>
@@ -157,6 +153,10 @@
                       }}</v-subheader
                     >
                   </v-flex>
+                  <v-btn text @click="exportNode">
+                    Export
+                    <v-icon right dark color="primary">file_download</v-icon>
+                  </v-btn>
                 </v-layout>
 
                 <v-layout row>

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -142,6 +142,10 @@
                       @click:append-outer="sendNodeAction"
                     ></v-select>
                   </v-flex>
+                  <v-btn color="green darken-1" text @click="exportNode">
+                    Export
+                  <v-icon right dark>file_download</v-icon>
+                  </v-btn>
                 </v-layout>
 
                 <v-layout row>
@@ -970,6 +974,10 @@ export default {
         .catch(error => {
           console.log(error)
         })
+    },
+    exportNode () {
+      var settings = this.getSettingsJSON()
+      this.$listeners.export(settings, 'settings')
     },
     async importScenes () {
       if (

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -144,7 +144,7 @@
                   </v-flex>
                   <v-btn color="green darken-1" text @click="exportNode">
                     Export
-                  <v-icon right dark>file_download</v-icon>
+                    <v-icon right dark>file_download</v-icon>
                   </v-btn>
                 </v-layout>
 
@@ -976,8 +976,11 @@ export default {
         })
     },
     exportNode () {
-      var settings = this.getSettingsJSON()
-      this.$listeners.export(settings, 'settings')
+      this.$listeners.export(
+        this.selectedNode,
+        'node_' + this.selectedNode.id,
+        'json'
+      )
     },
     async importScenes () {
       if (

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -591,9 +591,8 @@ export default {
         }
       } catch (error) {}
     },
-    exportSettings () {
-      var settings = this.getSettingsJSON()
-      this.$listeners.export(settings, 'settings')
+    exportNode () {
+      this.$listeners.export(this.selectedNode, 'node_'+this.selectedNode.id, 'json')
     },
     getSettingsJSON () {
       return {

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -591,8 +591,9 @@ export default {
         }
       } catch (error) {}
     },
-    exportNode () {
-      this.$listeners.export(this.selectedNode, 'node_'+this.selectedNode.id, 'json')
+    exportSettings () {
+      var settings = this.getSettingsJSON()
+      this.$listeners.export(settings, 'settings')
     },
     getSettingsJSON () {
       return {


### PR DESCRIPTION
I added an Export option for nodes.. Currently this export button can help on debugging issues.

Info:

- Per Node Export
- Discreet location no right side, next to node ID
- Output is Json format

Export Screenshot:
![exportNode](https://user-images.githubusercontent.com/4048920/102181612-32f24500-3eab-11eb-8b87-1a87567e8361.jpg)

