### PR TITLE
[fix] Detail on naming - Notifications  Names

### DIFF
--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -1471,7 +1471,8 @@ Gateway.prototype.discoverValue = function (node, vId) {
         // https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/notifications.json
         cfg = copy(hassCfg.sensor_generic)
         if (valueId.propertyKey) {
-          cfg.object_id = 'notification_' + valueId.property + '_' + valueId.propertyKey
+          cfg.object_id =
+            'notification_' + valueId.property + '_' + valueId.propertyKey
         } else {
           cfg.object_id = 'notification_' + valueId.property
         }

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -1605,7 +1605,7 @@ Gateway.prototype.discoverValue = function (node, vId) {
 
     // Check if another value already exists and add the index to object_id to make it unique
     if (node.hassDevices[cfg.type + '_' + cfg.object_id]) {
-      cfg.object_id += '_' + valueId.property
+      cfg.object_id += '_' + valueId.endpoint
     }
 
     // Set a friendly name for this component

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -568,7 +568,6 @@ function deviceInfo (node, nodeName) {
 function getDiscoveryTopic (hassDevice, nodeName) {
   return `${hassDevice.type}/${nodeName}/${hassDevice.object_id}/config`
 }
-
 /**
  * Calculate the correct template string to use for modes templates
  * based on gateway settings and mapped mode values
@@ -1471,7 +1470,11 @@ Gateway.prototype.discoverValue = function (node, vId) {
         // https://github.com/zwave-js/node-zwave-js/blob/master/packages/zwave-js/src/lib/commandclass/NotificationCC.ts
         // https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/notifications.json
         cfg = copy(hassCfg.sensor_generic)
-        cfg.object_id = 'notification_' + valueId.property
+        if (valueId.propertyKey) {
+          cfg.object_id = 'notification_' + valueId.property + '_' + valueId.propertyKey
+        } else {
+          cfg.object_id = 'notification_' + valueId.property
+        }
         cfg.discovery_payload.icon = 'mdi:alarm-light'
         break
       case CommandClasses['Multilevel Sensor']:


### PR DESCRIPTION
Multiple times happens on notification names during discovery to have a name like:
```
sensor_notification_Power Management_Power Management
```
It would be better if these names where:
```
sensor_notification_Power Management_Motion
```
This tries to avoid using the "duplicate" name by setting on Notifications the propertyKey

Also this happens with betteries, and other endpoints. when duplication happens.  It is good idea to use endpoint number as extension instead of "repeating" the same property name.