### PR TITLE
[feat] Hass: Add Translation of states list to value_template map and Notification Command Class first to use this

### DIFF
--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -1520,7 +1520,7 @@ Gateway.prototype.discoverValue = function (node, vId) {
         }
         switch (valueId.propertyKey) {
           case 'Motion sensor status':
-            cfg.discovery_payload.icon = 'hass:walk'
+            cfg.discovery_payload.icon = 'mdi:motion-sensor'
             break
           default:
             cfg.discovery_payload.icon = 'mdi:alarm-light'

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -631,7 +631,7 @@ function getMappedStateTemplate (state, defaultValueKey) {
 
   return `{{ {${map.join(
     ','
-  )}}[value_json.value] | default(${defaultValue}}) }}`
+  )}}[value_json.value] | default(${defaultValue}) }}`
 }
 
 /**

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -1518,7 +1518,13 @@ Gateway.prototype.discoverValue = function (node, vId) {
         } else {
           cfg.object_id = 'notification_' + valueId.property
         }
-        cfg.discovery_payload.icon = 'mdi:alarm-light'
+        switch (valueId.propertyKey) {
+          case 'Motion sensor status':
+            cfg.discovery_payload.icon = 'hass:walk'
+            break
+          default:
+            cfg.discovery_payload.icon = 'mdi:alarm-light'
+        }
         if (valueId.list) {
           cfg.discovery_payload.value_template = getMappedStateTemplate(
             valueId.states,

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -615,8 +615,7 @@ function getMappedValuesTemplate (modeMap, defaultValue) {
  */
 function getMappedStateTemplate (state, defaultValueKey) {
   const map = []
-  let defaultValue = 'clear'
-
+  let defaultValue = 'value_json.value'
   for (const listKey in state) {
     map.push(
       `${
@@ -626,13 +625,13 @@ function getMappedStateTemplate (state, defaultValueKey) {
       }: "${state[listKey].text}"`
     )
     if (state[listKey].value === defaultValueKey) {
-      defaultValue = state[listKey].text
+      defaultValue = `'${state[listKey].text}'`
     }
   }
 
   return `{{ {${map.join(
     ','
-  )}}[value_json.value] | default('${defaultValue}') }}`
+  )}}[value_json.value] | default(${defaultValue}}) }}`
 }
 
 /**
@@ -1528,7 +1527,7 @@ Gateway.prototype.discoverValue = function (node, vId) {
         if (valueId.list) {
           cfg.discovery_payload.value_template = getMappedStateTemplate(
             valueId.states,
-            0
+            valueId.default
           )
         }
         break

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -1489,6 +1489,10 @@ Gateway.prototype.discoverValue = function (node, vId) {
           cfg.object_id = 'notification_' + valueId.property
         }
         cfg.discovery_payload.icon = 'mdi:alarm-light'
+        payload.test = getMappedValuesTemplate(
+          valueId.states,
+          'clear'
+        )
         break
       case CommandClasses['Multilevel Sensor']:
       case CommandClasses.Meter:

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -629,9 +629,7 @@ function getMappedStateTemplate (state, defaultValueKey) {
     }
   }
 
-  return `{{ {${map.join(
-    ','
-  )}}[value_json.value] | default(${defaultValue}) }}`
+  return `{{ {${map.join(',')}}[value_json.value] | default(${defaultValue}) }}`
 }
 
 /**

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -605,6 +605,22 @@ function getMappedValuesTemplate (modeMap, defaultValue) {
   )}}[value_json.value] | default('${defaultValue}') }}`
 }
 
+function getMappedStateTemplate (state, defaultValueKey) {
+  const map = []
+  let defaultValue = 'clear'
+
+  for (const listKey in state) {
+    map.push(`${state[listKey].value}: "${state[listKey].text}"`)
+    if (state[listKey].value === defaultValueKey) {
+      defaultValue = state[listKey].text
+    }
+  }
+
+  return `{{ {${map.join(
+    ','
+  )}}[value_json.value] | default('${defaultValue}') }}`
+}
+
 /**
  * Retrives the value of a property from the node valueId
  *
@@ -1489,10 +1505,12 @@ Gateway.prototype.discoverValue = function (node, vId) {
           cfg.object_id = 'notification_' + valueId.property
         }
         cfg.discovery_payload.icon = 'mdi:alarm-light'
-        payload.test = getMappedValuesTemplate(
-          valueId.states,
-          'clear'
-        )
+        if (valueId.list) {
+          cfg.discovery_payload.value_template = getMappedStateTemplate(
+            valueId.states,
+            0
+          )
+        }
         break
       case CommandClasses['Multilevel Sensor']:
       case CommandClasses.Meter:

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -605,12 +605,26 @@ function getMappedValuesTemplate (modeMap, defaultValue) {
   )}}[value_json.value] | default('${defaultValue}') }}`
 }
 
+/**
+ * Calculate the correct template string to use for templates with state
+ * list based on gateway settings and mapped mode values
+ *
+ * @param {Object} state The object list which is translated to map
+ * @param {String} defaultValueKey The key to use for default value
+ * @returns {String} The template to use for the template
+ */
 function getMappedStateTemplate (state, defaultValueKey) {
   const map = []
   let defaultValue = 'clear'
 
   for (const listKey in state) {
-    map.push(`${state[listKey].value}: "${state[listKey].text}"`)
+    map.push(
+      `${
+        typeof state[listKey].value === 'number'
+          ? state[listKey].value
+          : '"' + state[listKey].value + '"'
+      }: "${state[listKey].text}"`
+    )
     if (state[listKey].value === defaultValueKey) {
       defaultValue = state[listKey].text
     }


### PR DESCRIPTION
Make Sensors of Notification CC provide translated values to Home assistant.

An example is Motion sensors. While the state is 0 or 8, this is not a nice to look into.
The real values per z-wave specification are idle and 'Motion detection'.

This patch converts the sensor values showin in HASS in human readable form.

<img width="455" alt="Screenshot 2020-12-22 at 09 01 57" src="https://user-images.githubusercontent.com/4048920/102864905-39e20000-4435-11eb-919c-dc1a42106d12.png">
