### PR TITLE
fix: run new build:full command to build zwave-js

### DIFF
--- a/docker/Dockerfile.contrib
+++ b/docker/Dockerfile.contrib
@@ -24,7 +24,7 @@ USER node
 WORKDIR /home/node/node-zwave-js
 RUN rm -f package-lock.json
 RUN yarn install --network-timeout=${YARN_NETWORK_TIMEOUT}
-RUN yarn run build
+RUN yarn run build:full
 RUN yarn install --production --frozen-lockfile
 RUN for i in config core serial shared; do \
     cd packages/$i && \


### PR DESCRIPTION
Yesterday I did some changes to speed up CI runs in zwave-js. One big offender was building the TS sources which essentially built the same packages over and over.
As a result I split the build step into two - one for packaging etc. (`build:full`) and one for small updates (`build`).