### PR TITLE
fix(hass): lock payload and state

### DIFF
--- a/hass/configurations.js
+++ b/hass/configurations.js
@@ -278,8 +278,7 @@ module.exports = {
       state_unlocked: 0,
       payload_lock: 255,
       payload_unlock: 0,
-      value_template:
-        '{{ value_json.value }}'
+      value_template: '{{ value_json.value }}'
     }
   },
 

--- a/hass/configurations.js
+++ b/hass/configurations.js
@@ -274,10 +274,12 @@ module.exports = {
     object_id: 'lock',
     discovery_payload: {
       command_topic: true,
-      state_locked: 'true',
-      state_unlocked: 'false',
+      state_locked: 255,
+      state_unlocked: 0,
+      payload_lock: 255,
+      payload_unlock: 0,
       value_template:
-        '{% if value_json.value == false %} false {% elif value_json.value == true %} true {% else %} unknown {% endif %}'
+        '{{ value_json.value }}'
     }
   },
 


### PR DESCRIPTION
fixes #137 

The Locks uses numbers(integers) instead of boolean with the new driver. update the payload