### PR TITLE
fix: use yarn link instead of yalc in Dockerfile.contrib

### DIFF
--- a/docker/Dockerfile.contrib
+++ b/docker/Dockerfile.contrib
@@ -18,7 +18,6 @@ COPY --chown=node zwavejs2mqtt /home/node/zwavejs2mqtt
 FROM ${SRC} AS build
 ARG YARN_NETWORK_TIMEOUT=30000
 USER root
-RUN yarn global add yalc
 RUN apt-get update && apt-get install -y jq
 USER node
 WORKDIR /home/node/node-zwave-js
@@ -30,26 +29,21 @@ RUN for i in config core serial shared; do \
     cd packages/$i && \
     yarn version --no-git-tag-version --new-version $(yarn versions --json| \
         jq -r '[.data."@zwave-js/'${i}'"]'[0])-$(git rev-parse --short HEAD) && \
-    yalc publish && \
+    yarn link && \
     cd ../..; \
     done
 RUN cd packages/zwave-js && \
     yarn version --no-git-tag-version --new-version $(yarn versions --json| \
         jq -r '[.data."zwave-js"]'[0])-$(git rev-parse --short HEAD) && \
-    yalc publish
+    yarn link
 
 WORKDIR /home/node/zwavejs2mqtt
-RUN rm -f package-lock.json
-RUN yalc add zwave-js && \
-    yalc add @zwave-js/config && \
-    yalc add @zwave-js/core && \
-    yalc add @zwave-js/shared && \
-    yalc add @zwave-js/serial
 RUN yarn install --network-timeout=${YARN_NETWORK_TIMEOUT}
 RUN yarn run build
 RUN yarn install --production --frozen-lockfile
 RUN yarn version -s --no-git-tag-version --new-version $(yarn versions --json| \
     jq -r .data.zwavejs2mqtt)+$(git rev-parse --short HEAD)
+RUN yarn link zwave-js && yarn link @zwave-js/core
 
 RUN mkdir my_dist
 RUN cp -Lr .git app.js package.json bin config dist hass lib public store views node_modules my_dist/

--- a/docker/Dockerfile.contrib
+++ b/docker/Dockerfile.contrib
@@ -43,7 +43,7 @@ RUN yarn run build
 RUN yarn install --production --frozen-lockfile
 RUN yarn version -s --no-git-tag-version --new-version $(yarn versions --json| \
     jq -r .data.zwavejs2mqtt)+$(git rev-parse --short HEAD)
-RUN yarn link zwave-js && yarn link @zwave-js/core
+RUN yarn link zwave-js
 
 RUN mkdir my_dist
 RUN cp -Lr .git app.js package.json bin config dist hass lib public store views node_modules my_dist/


### PR DESCRIPTION
I guess this could avoid the duplicate config dependencies we're currently seeing. However I couldn't test it since I have no clue how to run the container after executing the command from the docs.

/cc @larstobi 

fixes: #173 
(I hope)