### PR TITLE
fix: Read meters from ConfigManager

### DIFF
--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -17,7 +17,10 @@ module.exports = {
   },
   meterType (ccSpecific, configManager) {
     const meter = configManager.lookupMeter(ccSpecific.meterType)
-    const scale = configManager.lookupMeterScale(ccSpecific.meterType, ccSpecific.scale)
+    const scale = configManager.lookupMeterScale(
+      ccSpecific.meterType,
+      ccSpecific.scale
+    )
 
     const cfg = {
       sensor: (meter ? meter.name : 'unknown') + ccSpecific.meterType,

--- a/lib/Constants.js
+++ b/lib/Constants.js
@@ -1,5 +1,3 @@
-const { lookupMeterScale, lookupMeter } = require('@zwave-js/config')
-
 module.exports = {
   // https://github.com/OpenZWave/open-zwave/blob/0d94c9427bbd19e47457578bccc60b16c6679b49/config/Localization.xml#L606
   _productionMap: {
@@ -17,9 +15,9 @@ module.exports = {
       }
     }
   },
-  meterType (ccSpecific) {
-    const meter = lookupMeter(ccSpecific.meterType)
-    const scale = lookupMeterScale(ccSpecific.meterType, ccSpecific.scale)
+  meterType (ccSpecific, configManager) {
+    const meter = configManager.lookupMeter(ccSpecific.meterType)
+    const scale = configManager.lookupMeterScale(ccSpecific.meterType, ccSpecific.scale)
 
     const cfg = {
       sensor: (meter ? meter.name : 'unknown') + ccSpecific.meterType,

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -1595,7 +1595,10 @@ Gateway.prototype.discoverValue = function (node, vId) {
           // In some cases Metering devices offer Reset option or DeltaTime sensors, but do not include ccSpecific
           // information. With this change, we target only the sensors and not the additional Properties.
           if (valueId.ccSpecific) {
-            sensor = Constants.meterType(valueId.ccSpecific, this.zwave.driver.configManager)
+            sensor = Constants.meterType(
+              valueId.ccSpecific,
+              this.zwave.driver.configManager
+            )
           } else {
             return
           }

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -1595,7 +1595,7 @@ Gateway.prototype.discoverValue = function (node, vId) {
           // In some cases Metering devices offer Reset option or DeltaTime sensors, but do not include ccSpecific
           // information. With this change, we target only the sensors and not the additional Properties.
           if (valueId.ccSpecific) {
-            sensor = Constants.meterType(valueId.ccSpecific)
+            sensor = Constants.meterType(valueId.ccSpecific,this.zwave.driver.configManager)
           } else {
             return
           }

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -1595,7 +1595,7 @@ Gateway.prototype.discoverValue = function (node, vId) {
           // In some cases Metering devices offer Reset option or DeltaTime sensors, but do not include ccSpecific
           // information. With this change, we target only the sensors and not the additional Properties.
           if (valueId.ccSpecific) {
-            sensor = Constants.meterType(valueId.ccSpecific,this.zwave.driver.configManager)
+            sensor = Constants.meterType(valueId.ccSpecific, this.zwave.driver.configManager)
           } else {
             return
           }


### PR DESCRIPTION
Upstream has new ConfigManager, lookupMeter is accessible there.