### PR TITLE
fix: send loglevel to driver as a number

### DIFF
--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -18,6 +18,7 @@ const store = reqlib('config/store.js')
 const storeDir = utils.joinPath(true, reqlib('config/app.js').storeDir)
 const logger = require('./logger.js').module('Zwave')
 const inherits = require('util').inherits
+const loglevels = require('triple-beam').configs.npm.levels
 
 const ZWAVE_STATUS = {
   connected: 'connected',
@@ -1295,7 +1296,7 @@ ZwaveClient.prototype.connect = async function () {
         logConfig: {
           // https://zwave-js.github.io/node-zwave-js/#/api/driver?id=logconfig
           enabled: this.cfg.logEnabled,
-          level: this.cfg.logLevel,
+          level: loglevels[this.cfg.logLevel],
           logToFile: this.cfg.logToFile,
           filename: ZWAVEJS_LOG_FILE,
           forceConsole: true


### PR DESCRIPTION
Upstream logConfig interface expects the log level to be sent as a number