### PR TITLE
[chore] upgrade zwavejs to beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
         "vuetify": "^2.4.0",
         "vuex": "^3.6.0",
         "winston": "^3.3.3",
-        "zwave-js": "^6.0.0-alpha.3"
+        "zwave-js": "^6.0.0-beta.0"
       },
       "bin": {
         "zwavejs2mqtt": "bin/www"
@@ -2835,12 +2835,12 @@
       "dev": true
     },
     "node_modules/@zwave-js/config": {
-      "version": "6.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-6.0.0-alpha.3.tgz",
-      "integrity": "sha512-+9yAqhQ1J3OF4+ECrJRPsa30ei7c9ROMoJkWgMwSU+pyyrLaSGSKTl/YTK5sruJYtQau27g/kugdb5DT48BKtw==",
+      "version": "6.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-6.0.0-beta.0.tgz",
+      "integrity": "sha512-YRBN5b0coG9gaZPkb5Fr6nt/JCSnkxiq3fP3CGtG3/YN1h6Gm5Twia3OYzYNBXjR8Z+h1Xiuzb5IUzRCk+8sKQ==",
       "dependencies": {
-        "@zwave-js/core": "^6.0.0-alpha.3",
-        "@zwave-js/shared": "^6.0.0-alpha.1",
+        "@zwave-js/core": "^6.0.0-beta.0",
+        "@zwave-js/shared": "^6.0.0-beta.0",
         "alcalzone-shared": "^3.0.1",
         "ansi-colors": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -2892,12 +2892,12 @@
       }
     },
     "node_modules/@zwave-js/core": {
-      "version": "6.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-6.0.0-alpha.3.tgz",
-      "integrity": "sha512-r3ZOYk0F4K5PTAVzJ9Ri9R4YoMRrFcxyY8h0as2NeJRamZfdQ6iVdXw72p9aSUNOuNoUjFihcoY3LklDD/AFAA==",
+      "version": "6.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-6.0.0-beta.0.tgz",
+      "integrity": "sha512-344o9gAcSEzqV/H4itc5ZKvnDQBut6VKYFjQdpD6mUWJ60+8PeuLgGIakZ1eQ65/rAnfDfIKqOazgIYGBVzgRQ==",
       "dependencies": {
         "@alcalzone/jsonl-db": "^1.2.3",
-        "@zwave-js/shared": "^6.0.0-alpha.1",
+        "@zwave-js/shared": "^6.0.0-beta.0",
         "alcalzone-shared": "^3.0.1",
         "ansi-colors": "^4.1.1",
         "moment": "^2.29.0",
@@ -2921,11 +2921,11 @@
       }
     },
     "node_modules/@zwave-js/serial": {
-      "version": "6.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-6.0.0-alpha.3.tgz",
-      "integrity": "sha512-G11nKPfrFu+oqDaD5LWHuwOegfiLEYrnWiIxl23xnGUoNidVF/rR2MTUcPzg7OIiV3GPrMiXA9Z+gao+xk2gjA==",
+      "version": "6.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-6.0.0-beta.0.tgz",
+      "integrity": "sha512-nRT68TGRPV/UUwOeXtR5WOdLDwOkEg6gFflgggH6GCv5zYAjC+mekAF1W2Tv2A0j3W9W/ZJGX3fz0lMUCk0LvQ==",
       "dependencies": {
-        "@zwave-js/core": "^6.0.0-alpha.3",
+        "@zwave-js/core": "^6.0.0-beta.0",
         "alcalzone-shared": "^3.0.1",
         "serialport": "^9.0.1",
         "winston": "^3.3.3"
@@ -2938,9 +2938,9 @@
       }
     },
     "node_modules/@zwave-js/shared": {
-      "version": "6.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-6.0.0-alpha.1.tgz",
-      "integrity": "sha512-waBt+LXUwNraB2h6H1yt64B2P8urxjbKC4pfFbaOC+do03+G7oxWCx4KbKgxt31U+Hgo9LBg6/lxDZMVG/qRKQ==",
+      "version": "6.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-6.0.0-beta.0.tgz",
+      "integrity": "sha512-WFAvatRPvTHvwagbWBvAan+s0PV60qp3imUFhh/h3LyxMn4miHndHPOGhM7bBzDA8xba66d9Ni5rAMgWr/FpeQ==",
       "dependencies": {
         "alcalzone-shared": "^3.0.1"
       },
@@ -21755,17 +21755,17 @@
       }
     },
     "node_modules/zwave-js": {
-      "version": "6.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-6.0.0-alpha.3.tgz",
-      "integrity": "sha512-jebdfhIswT2ZBARrx/AtBtoDoPG8V3I1wEINTE83yW/D9TsSHFS5Gy4GDMoMZSI2V3C5qTGlmq60AiCZWZwD9w==",
+      "version": "6.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-6.0.0-beta.0.tgz",
+      "integrity": "sha512-MFLNnDdLmSphu4ouyF5U4dxLwFht9lIZ9Xd7R2Mi43WX4tp/s0RLSszOWI1vS3mT4eYHCTcRh7p1sO9E8hhAAg==",
       "dependencies": {
         "@alcalzone/jsonl-db": "^1.2.3",
         "@sentry/integrations": "^5.24.2",
         "@sentry/node": "^5.24.2",
-        "@zwave-js/config": "^6.0.0-alpha.3",
-        "@zwave-js/core": "^6.0.0-alpha.3",
-        "@zwave-js/serial": "^6.0.0-alpha.3",
-        "@zwave-js/shared": "^6.0.0-alpha.1",
+        "@zwave-js/config": "^6.0.0-beta.0",
+        "@zwave-js/core": "^6.0.0-beta.0",
+        "@zwave-js/serial": "^6.0.0-beta.0",
+        "@zwave-js/shared": "^6.0.0-beta.0",
         "alcalzone-shared": "^3.0.1",
         "ansi-colors": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -24145,12 +24145,12 @@
       "dev": true
     },
     "@zwave-js/config": {
-      "version": "6.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-6.0.0-alpha.3.tgz",
-      "integrity": "sha512-+9yAqhQ1J3OF4+ECrJRPsa30ei7c9ROMoJkWgMwSU+pyyrLaSGSKTl/YTK5sruJYtQau27g/kugdb5DT48BKtw==",
+      "version": "6.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/config/-/config-6.0.0-beta.0.tgz",
+      "integrity": "sha512-YRBN5b0coG9gaZPkb5Fr6nt/JCSnkxiq3fP3CGtG3/YN1h6Gm5Twia3OYzYNBXjR8Z+h1Xiuzb5IUzRCk+8sKQ==",
       "requires": {
-        "@zwave-js/core": "^6.0.0-alpha.3",
-        "@zwave-js/shared": "^6.0.0-alpha.1",
+        "@zwave-js/core": "^6.0.0-beta.0",
+        "@zwave-js/shared": "^6.0.0-beta.0",
         "alcalzone-shared": "^3.0.1",
         "ansi-colors": "^4.1.1",
         "fs-extra": "^9.0.1",
@@ -24186,12 +24186,12 @@
       }
     },
     "@zwave-js/core": {
-      "version": "6.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-6.0.0-alpha.3.tgz",
-      "integrity": "sha512-r3ZOYk0F4K5PTAVzJ9Ri9R4YoMRrFcxyY8h0as2NeJRamZfdQ6iVdXw72p9aSUNOuNoUjFihcoY3LklDD/AFAA==",
+      "version": "6.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/core/-/core-6.0.0-beta.0.tgz",
+      "integrity": "sha512-344o9gAcSEzqV/H4itc5ZKvnDQBut6VKYFjQdpD6mUWJ60+8PeuLgGIakZ1eQ65/rAnfDfIKqOazgIYGBVzgRQ==",
       "requires": {
         "@alcalzone/jsonl-db": "^1.2.3",
-        "@zwave-js/shared": "^6.0.0-alpha.1",
+        "@zwave-js/shared": "^6.0.0-beta.0",
         "alcalzone-shared": "^3.0.1",
         "ansi-colors": "^4.1.1",
         "moment": "^2.29.0",
@@ -24208,20 +24208,20 @@
       }
     },
     "@zwave-js/serial": {
-      "version": "6.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-6.0.0-alpha.3.tgz",
-      "integrity": "sha512-G11nKPfrFu+oqDaD5LWHuwOegfiLEYrnWiIxl23xnGUoNidVF/rR2MTUcPzg7OIiV3GPrMiXA9Z+gao+xk2gjA==",
+      "version": "6.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/serial/-/serial-6.0.0-beta.0.tgz",
+      "integrity": "sha512-nRT68TGRPV/UUwOeXtR5WOdLDwOkEg6gFflgggH6GCv5zYAjC+mekAF1W2Tv2A0j3W9W/ZJGX3fz0lMUCk0LvQ==",
       "requires": {
-        "@zwave-js/core": "^6.0.0-alpha.3",
+        "@zwave-js/core": "^6.0.0-beta.0",
         "alcalzone-shared": "^3.0.1",
         "serialport": "^9.0.1",
         "winston": "^3.3.3"
       }
     },
     "@zwave-js/shared": {
-      "version": "6.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-6.0.0-alpha.1.tgz",
-      "integrity": "sha512-waBt+LXUwNraB2h6H1yt64B2P8urxjbKC4pfFbaOC+do03+G7oxWCx4KbKgxt31U+Hgo9LBg6/lxDZMVG/qRKQ==",
+      "version": "6.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/shared/-/shared-6.0.0-beta.0.tgz",
+      "integrity": "sha512-WFAvatRPvTHvwagbWBvAan+s0PV60qp3imUFhh/h3LyxMn4miHndHPOGhM7bBzDA8xba66d9Ni5rAMgWr/FpeQ==",
       "requires": {
         "alcalzone-shared": "^3.0.1"
       }
@@ -39141,17 +39141,17 @@
       "dev": true
     },
     "zwave-js": {
-      "version": "6.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-6.0.0-alpha.3.tgz",
-      "integrity": "sha512-jebdfhIswT2ZBARrx/AtBtoDoPG8V3I1wEINTE83yW/D9TsSHFS5Gy4GDMoMZSI2V3C5qTGlmq60AiCZWZwD9w==",
+      "version": "6.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/zwave-js/-/zwave-js-6.0.0-beta.0.tgz",
+      "integrity": "sha512-MFLNnDdLmSphu4ouyF5U4dxLwFht9lIZ9Xd7R2Mi43WX4tp/s0RLSszOWI1vS3mT4eYHCTcRh7p1sO9E8hhAAg==",
       "requires": {
         "@alcalzone/jsonl-db": "^1.2.3",
         "@sentry/integrations": "^5.24.2",
         "@sentry/node": "^5.24.2",
-        "@zwave-js/config": "^6.0.0-alpha.3",
-        "@zwave-js/core": "^6.0.0-alpha.3",
-        "@zwave-js/serial": "^6.0.0-alpha.3",
-        "@zwave-js/shared": "^6.0.0-alpha.1",
+        "@zwave-js/config": "^6.0.0-beta.0",
+        "@zwave-js/core": "^6.0.0-beta.0",
+        "@zwave-js/serial": "^6.0.0-beta.0",
+        "@zwave-js/shared": "^6.0.0-beta.0",
         "alcalzone-shared": "^3.0.1",
         "ansi-colors": "^4.1.1",
         "fs-extra": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
     "vuetify": "^2.4.0",
     "vuex": "^3.6.0",
     "winston": "^3.3.3",
-    "zwave-js": "^6.0.0-alpha.3"
+    "zwave-js": "^6.0.0-beta.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",


### PR DESCRIPTION
Update to latest zwave-js 6.0.0-beta.0

fixes:
- logging
- Meter updates