### PR TITLE
fix: remove Thermofloor Z-trm2fx specific configuration (fix #202)

### DIFF
--- a/hass/devices.js
+++ b/hass/devices.js
@@ -214,33 +214,6 @@ module.exports = {
       }
     }
   ],
-  '411-514-3': [
-    // Heatit Thermostat TF 056 (ThermoFloor AS)
-    {
-      type: 'climate',
-      object_id: 'thermostat',
-      values: [
-        '64-0-mode',
-        '49-0-Air temperature',
-        '67-0-setpoint-1',
-        '67-0-setpoint-2'
-      ],
-      mode_map: { off: 0, heat: 1, cool: 2 },
-      setpoint_topic: { 1: '67-0-setpoint-1', 2: '67-0-setpoint-2' },
-      default_setpoint: '67-0-setpoint-1',
-      discovery_payload: {
-        min_temp: 15,
-        max_temp: 30,
-        modes: ['off', 'heat', 'cool'],
-        mode_state_topic: '64-0-mode',
-        mode_command_topic: true,
-        current_temperature_topic: '49-0-Air temperature',
-        current_temperature_template: '{{ value_json.value }}',
-        temperature_state_template: '{{ value_json.value }}',
-        temperature_command_topic: true
-      }
-    }
-  ],
   '798-1-5': [
     // Inovelli LZW42 Multi-Color Bulb
     {


### PR DESCRIPTION
This fixes #202 by removing blocking configuration. See the the issue for more information.