### PR TITLE
fix: HASS Discovery - Name - First character fix

### DIFF
--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -688,6 +688,7 @@ function getEntityName (node, valueId, cfg, entityTemplate) {
     .replace(/%o/g, cfg.object_id)
     .replace(/%n/g, node.name || NODE_PREFIX + node.id)
     .replace(/%l/g, label)
+    .replace(/^[-_ ]/, '')
 }
 
 /**


### PR DESCRIPTION
Apply a fix for better Naming in Home Assistant. Add a replace of the first character if it is a hyphen `-`, understore `_` or space ` `
by cleaning up the first character, in case of location is empty or unused, like in default payload. Will then clean up the this characted.

fixes #162 