### PR TITLE
fix: central scene notification argument list changed in Zwave-JS 6.0

### DIFF
--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -384,6 +384,10 @@ function onNodeValueAdded (zwaveNode, args) {
 }
 
 function onNodeValueNotification (zwaveNode, args) {
+  logger.debug(
+    'In onNodeValueNotification: Overwriting args.newValue with args.value'
+  )
+  args.newValue = args.value
   onNodeValueUpdated.call(this, zwaveNode, args, true)
 }
 


### PR DESCRIPTION
Resolves https://github.com/zwave-js/zwavejs2mqtt/issues/210

The correct fix is to change to a stateless event notification, rather than tracking a stateful value, but this should work as a workaround.