### PR TITLE
fix: error in filter options for null strings

### DIFF
--- a/src/modules/NodeCollection.js
+++ b/src/modules/NodeCollection.js
@@ -127,7 +127,7 @@ export class NodeCollection {
   values (property) {
     const uniqueMap = {}
     this.nodes.forEach(node => {
-      if (!!node[property]) {
+      if (node[property]) {
         const strVal = this._strValue(node[property])
         uniqueMap[strVal] = uniqueMap[strVal] || node[property]
       }

--- a/src/modules/NodeCollection.js
+++ b/src/modules/NodeCollection.js
@@ -127,8 +127,10 @@ export class NodeCollection {
   values (property) {
     const uniqueMap = {}
     this.nodes.forEach(node => {
-      const strVal = this._strValue(node[property])
-      uniqueMap[strVal] = uniqueMap[strVal] || node[property]
+      if (!!node[property]) {
+        const strVal = this._strValue(node[property])
+        uniqueMap[strVal] = uniqueMap[strVal] || node[property]
+      }
     })
     return Object.keys(uniqueMap)
       .sort()


### PR DESCRIPTION
If node values are `null` or `undefined` errors like the following show up in the browser console and the selection of string values for columns in the node table is not available:
```
vue.esm.js?a026:628 [Vue warn]: Error in render: "TypeError: Cannot read property 'header' of null"
found in
---> <VSelect>
       <VForm>
         <ColumnFilterString> at src/components/nodes-table/ColumnFilterString.vue
```
This PR fixes this problem by only considering non-null/non-undefined values for <v-select>.