### PR TITLE
feat: reduce HASS device noise

### DIFF
--- a/docs/usage/setup.md
+++ b/docs/usage/setup.md
@@ -169,6 +169,7 @@ Gateway settings:
   - `%pn`: valueId property name (fallback to device type)
   - `%o`: HASS object_id
   - `%l`: valueId label (fallback to object_id)
+- **Create secondary devices**: Creates secondary non essential devices. More details under Guide/homeassistant document
 
 Once finished press `SAVE` and gateway will start Zwave Network Scan, than go to 'Control Panel' section and wait until the scan is completed to check discovered devices and manage them.
 

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -1625,6 +1625,16 @@ Gateway.prototype.discoverValue = function (node, vId) {
           // https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/meters.json
           // In some cases Metering devices offer Reset option or DeltaTime sensors, but do not include ccSpecific
           // information. With this change, we target only the sensors and not the additional Properties.
+
+          // check if we want to expose all non essential values as devices
+          const secondaryMeters = ['deltaTime', 'previousValue']
+          if (
+            this.config.secondaryDevices &&
+            secondaryMeters.includes(valueId.property)
+          ) {
+            return
+          }
+
           if (valueId.ccSpecific) {
             sensor = Constants.meterType(
               valueId.ccSpecific,

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -393,6 +393,13 @@
                           <code>%l</code>: valueId label (fallback to object_id)
                         </div>
                       </v-flex>
+                      <v-flex xs6 v-if="gateway.hassDiscovery">
+                        <v-text-field
+                          v-model="gateway.secondaryDevices"
+                          label="Create Secondary Devices"
+                          hint="Secondary non essential devices will be created with this switch"
+                        ></v-text-field>
+                      </v-flex>
                     </v-layout>
                     <v-data-table
                       :headers="headers"

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -396,7 +396,7 @@
                       <v-flex xs6 v-if="gateway.hassDiscovery">
                         <v-text-field
                           v-model="gateway.secondaryDevices"
-                          label="Create Secondary Devices"
+                          label="Create secondary eevices"
                           hint="Secondary non essential devices will be created with this switch"
                         ></v-text-field>
                       </v-flex>


### PR DESCRIPTION
add support for secondary/non essential devices

By default some devices will not be created if they are considered secondary.
- Add switch in settings
- Add list of devices (for Meters)
- Add documentation

improvement based on issue #232 