### PR TITLE
fix(ui): inconsistent, unsorted node selection

### DIFF
--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -296,7 +296,15 @@
                     <v-select
                       label="Node"
                       v-model="group.node"
-                      :items="nodes.filter(n => !n.failed)"
+                      :items="
+                        nodes
+                          .filter(n => !n.failed)
+                          .sort((n1, n2) =>
+                            n1._name.toLowerCase() < n2._name.toLowerCase()
+                              ? -1
+                              : 1
+                          )
+                      "
                       return-object
                       @change="resetGroup"
                       item-text="_name"
@@ -355,7 +363,15 @@
                     <v-combobox
                       label="Target"
                       v-model="group.target"
-                      :items="nodes.filter(n => !n.failed && n != group.node)"
+                      :items="
+                        nodes
+                          .filter(n => !n.failed && n != group.node)
+                          .sort((n1, n2) =>
+                            n1._name.toLowerCase() < n2._name.toLowerCase()
+                              ? -1
+                              : 1
+                          )
+                      "
                       return-object
                       hint="Select the node from the list or digit the node ID"
                       persistent-hint

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -296,15 +296,7 @@
                     <v-select
                       label="Node"
                       v-model="group.node"
-                      :items="
-                        nodes
-                          .filter(n => !n.failed)
-                          .sort((n1, n2) =>
-                            n1._name.toLowerCase() < n2._name.toLowerCase()
-                              ? -1
-                              : 1
-                          )
-                      "
+                      :items="sortedNodes"
                       return-object
                       @change="resetGroup"
                       item-text="_name"
@@ -363,15 +355,7 @@
                     <v-combobox
                       label="Target"
                       v-model="group.target"
-                      :items="
-                        nodes
-                          .filter(n => !n.failed && n != group.node)
-                          .sort((n1, n2) =>
-                            n1._name.toLowerCase() < n2._name.toLowerCase()
-                              ? -1
-                              : 1
-                          )
-                      "
+                      :items="sortedNodes.filter(n => n != group.node)"
                       return-object
                       hint="Select the node from the list or digit the node ID"
                       persistent-hint
@@ -586,6 +570,13 @@ export default {
     NodesTable
   },
   computed: {
+    sortedNodes () {
+      return this.nodes
+        .filter(n => !n.failed)
+        .sort((n1, n2) =>
+          n1._name.toLowerCase() < n2._name.toLowerCase() ? -1 : 1
+        )
+    },
     scenesWithId () {
       return this.scenes.map(s => {
         s.label = `[${s.sceneid}] ${s.label}`

--- a/src/components/dialogs/DialogSceneValue.vue
+++ b/src/components/dialogs/DialogSceneValue.vue
@@ -18,7 +18,13 @@
                   item-text="_name"
                   :rules="[required]"
                   item-value="id"
-                  :items="nodes.filter(n => !!n)"
+                  :items="
+                    nodes
+                      .filter(n => !n.failed)
+                      .sort((n1, n2) =>
+                        n1._name.toLowerCase() < n2._name.toLowerCase() ? -1 : 1
+                      )
+                  "
                 ></v-select>
               </v-flex>
               <v-flex v-if="editedValue.node" xs12>

--- a/src/components/dialogs/DialogSceneValue.vue
+++ b/src/components/dialogs/DialogSceneValue.vue
@@ -18,13 +18,7 @@
                   item-text="_name"
                   :rules="[required]"
                   item-value="id"
-                  :items="
-                    nodes
-                      .filter(n => !n.failed)
-                      .sort((n1, n2) =>
-                        n1._name.toLowerCase() < n2._name.toLowerCase() ? -1 : 1
-                      )
-                  "
+                  :items="sortedNodes"
                 ></v-select>
               </v-flex>
               <v-flex v-if="editedValue.node" xs12>
@@ -108,6 +102,15 @@ export default {
     title: String,
     editedValue: Object,
     nodes: Array
+  },
+  computed: {
+    sortedNodes () {
+      return this.nodes
+        .filter(n => !n.failed)
+        .sort((n1, n2) =>
+          n1._name.toLowerCase() < n2._name.toLowerCase() ? -1 : 1
+        )
+    }
   },
   watch: {
     // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
If you have a large number of nodes it is not easy to find the relevant ones in the selection list.
Therefore I suggest to sort them by display name (using `_name`).

Affected selections:
* groups: node and target selection
* scenes: node selection

In addition, the node selection in the scenes tab did not filter failed nodes, which has been changed for consistency too.