### PR TITLE
chore(docker): add zwave-js server port binding in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,7 +13,8 @@ services:
     volumes:
       - ./store:/usr/src/app/store
     ports:
-      - '8091:8091'
+      - '8091:8091'  # port for web interface
+      - '3000:3000'  # port for zwave-js websocket server
 networks:
   zwave:
 # volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -13,8 +13,8 @@ services:
     volumes:
       - ./store:/usr/src/app/store
     ports:
-      - '8091:8091'  # port for web interface
-      - '3000:3000'  # port for zwave-js websocket server
+      - '8091:8091' # port for web interface
+      - '3000:3000' # port for zwave-js websocket server
 networks:
   zwave:
 # volumes:


### PR DESCRIPTION
added port expose for new zwave-js websocket server and annotations to help the new.
