### PR TITLE
fix(ui): settings labels

### DIFF
--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -195,9 +195,9 @@
 
             <v-container cols="12" sm="6" class="ml-1">
               <v-switch
-                hint="Enable this to use Z2M only as Control Panel"
+                hint="Enable this to use zwavejs2mqtt only as Control Panel"
                 persistent-hint
-                label="Disable Gateway"
+                label="Disable MQTT Gateway"
                 v-model="mqtt.disabled"
               ></v-switch>
             </v-container>


### PR DESCRIPTION
Issue #472 

Temp "fix"

I'm thinking the settings panel needs to be rearranged a little.

This setting for example should be enable to enable instead of enable to disable. 

Also, I'm thinking the settings should be:
- General
- Zwave
- Enable WS server. (instead of inside of Zwave) (show the relevant options if toggle on)
- Enable MQTT Gateway. (show the relevant options if if toggle on) (opposite behavior from current)

Seems like an easy change so if you like the idea I'll figure out how to do it and submit another PR.
