### PR TITLE
feat: add time and time zone sync and added esbenp prettifier for yaml files in vsconfig

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,5 +12,8 @@
   "[markdown]": {
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
-  "standard.enable": false
+  "standard.enable": false,
+  "[yaml]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
 }

--- a/docker/Dockerfile.contrib
+++ b/docker/Dockerfile.contrib
@@ -18,7 +18,7 @@ COPY --chown=node zwavejs2mqtt /home/node/zwavejs2mqtt
 
 ##### BUILD #####
 FROM ${SRC} AS build
-ARG YARN_NETWORK_TIMEOUT=30000
+ARG YARN_NETWORK_TIMEOUT=300000
 USER root
 RUN apt-get update && apt-get install -y jq
 USER node

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.7'
+version: "3.7"
 services:
   zwavejs2mqtt:
     container_name: zwavejs2mqtt
@@ -9,12 +9,14 @@ services:
     networks:
       - zwave
     devices:
-      - '/dev/ttyACM0:/dev/ttyACM0'
+      - "/dev/ttyACM0:/dev/ttyACM0"
     volumes:
       - ./store:/usr/src/app/store
+      # - /etc/timezone:/etc/timezone:ro   # uncomment to sync timezone with host
+      # - /etc/localtime:/etc/localtime:ro # uncomment to sync time with host
     ports:
-      - '8091:8091' # port for web interface
-      - '3000:3000' # port for zwave-js websocket server
+      - "8091:8091" # port for web interface
+      - "3000:3000" # port for zwave-js websocket server
 networks:
   zwave:
 # volumes:


### PR DESCRIPTION
This addresses the time zone sync volumes to the docker-compose question that came up in slack today.

I ran the prettifier @blhoward2  recommended and it changed the vscode settings - i am not sure if that is something we want or if that file should be added to the .gitignore? I am assuming you can reject  a file in a PR?  I don't know how to run prettifier and not have it change the vscode settings...