### PR TITLE
fix: firmware target not set correctly

### DIFF
--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -2212,7 +2212,7 @@ ZwaveClient.prototype.refreshInfo = async function (nodeId) {
 }
 
 /**
- * Start a frimware uddate
+ * Start a firmware update
  *
  * @param {number} nodeId
  * @param {string} fileName
@@ -2246,7 +2246,7 @@ ZwaveClient.prototype.beginFirmwareUpdate = async function (
     }
 
     if (target >= 0) {
-      actualFirmware.target = target
+      actualFirmware.firmwareTarget = target
     }
 
     return zwaveNode.beginFirmwareUpdate(


### PR DESCRIPTION
When non-zero target is specified, it does not get copied to a data member that is passed to the beginFirmwareUpdate method.  This fixes that so that when the user specifies a non-zero target, it will be passed along.  This was causing a failure related to [zwave JS issue 1761](https://github.com/zwave-js/node-zwave-js/issues/1761)