### PR TITLE
bug: updated yarn timeout to avoid sporadic build errors

### DIFF
--- a/docker/Dockerfile.contrib
+++ b/docker/Dockerfile.contrib
@@ -18,7 +18,7 @@ COPY --chown=node zwavejs2mqtt /home/node/zwavejs2mqtt
 
 ##### BUILD #####
 FROM ${SRC} AS build
-ARG YARN_NETWORK_TIMEOUT=30000
+ARG YARN_NETWORK_TIMEOUT=300000
 USER root
 RUN apt-get update && apt-get install -y jq
 USER node


### PR DESCRIPTION
Yarn timeout of 30000 (aka 30 seconds) seems to result in sporadic build failures with an RPC timeout.  Affected yarn package varies.  I was getting in 1 in 3 failures using github webhooks and saw it once locally.

I set to 300000 (aka 5 minutes) and this resulted in over 40 builds with github webhooks.  In the spirit of reliability is more important than speed i think we should make this change.  I haven't tried a shorter value to find where the cut off is between good and bad.  Githib build times with this flag varied between ~30 minutes and ~hour.