### PR TITLE
fix: propertyKey may be zero

### DIFF
--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -1043,7 +1043,7 @@ Gateway.prototype.valueTopic = function (node, valueId, returnObject = false) {
         topic.push('endpoint_' + (valueId.endpoint || 0))
 
         topic.push(utils.removeSlash(valueId.propertyName))
-        if (valueId.propertyKey) {
+        if (valueId.propertyKey !== undefined) {
           topic.push(utils.removeSlash(valueId.propertyKey))
         }
         break
@@ -1056,7 +1056,7 @@ Gateway.prototype.valueTopic = function (node, valueId, returnObject = false) {
         topic.push(valueId.commandClass)
         topic.push(valueId.endpoint || '0')
         topic.push(utils.removeSlash(valueId.property))
-        if (valueId.propertyKey) {
+        if (valueId.propertyKey !== undefined) {
           topic.push(utils.removeSlash(valueId.propertyKey))
         }
         break


### PR DESCRIPTION
This fixes the missing color channel 0 for Color Switch CC and avoids value clashes between all values and color 0 when https://github.com/zwave-js/node-zwave-js/pull/1782 is merged.