### PR TITLE
chore: improve docker builds

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -29,7 +29,7 @@ jobs:
           tag-latest: true
           tag-semver: |
             {{version}}
-          tag-custom: "dev"
+          tag-custom: 'dev'
           label-custom: |
             org.opencontainers.image.vendor=zwave-js
             org.opencontainers.image.documentation=https://zwave-js.github.io/zwavejs2mqtt/#/

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,59 @@
+name: Docker Release
+
+on:
+  push:
+    branches:
+      - master
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: docker/setup-buildx-action@v1
+      - uses: docker/setup-qemu-action@v1
+      - name: Login to dockerhub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - id: docker_meta
+        uses: crazy-max/ghaction-docker-meta@v1
+        with:
+          images: zwavejs/zwavejs2mqtt
+          tag-sha: true
+          tag-latest: true
+          tag-semver: |
+            {{version}}
+          tag-custom: "dev"
+          label-custom: |
+            org.opencontainers.image.vendor=zwave-js
+            org.opencontainers.image.documentation=https://zwave-js.github.io/zwavejs2mqtt/#/
+            org.opencontainers.image.authors=Daniel Lando <daniel.sorridi@gmail.com>
+            org.opencontainers.image.url=https://zwave-js.github.io/zwavejs2mqtt/#/
+            maintainer=robertsLando
+
+      - name: Cache Docker layers
+        uses: actions/cache@v2
+        with:
+          path: /tmp/.buildx-cache
+          key: buildx-${{ github.ref }}-${{ github.sha }}
+          restore-keys: |
+            buildx-${{ github.ref }}-${{ github.sha }}
+            buildx-${{ github.ref }}
+            buildx-
+
+      - name: build+push
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/arm64,linux/amd64,linux/arm/v6,linux/arm/v7
+          file: docker/Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -29,7 +29,6 @@ jobs:
           tag-latest: true
           tag-semver: |
             {{version}}
-          tag-custom: 'dev'
           label-custom: |
             org.opencontainers.image.vendor=zwave-js
             org.opencontainers.image.documentation=https://zwave-js.github.io/zwavejs2mqtt/#/

--- a/.github/workflows/docker-test-amd64.yml
+++ b/.github/workflows/docker-test-amd64.yml
@@ -27,7 +27,7 @@ jobs:
           images: zwavejs/zwavejs2mqtt
           tag-sha: false
           tag-latest: false
-          tag-custom: "branch-${{ steps.ref-sanitized.outputs.result }}"
+          tag-custom: ${{ 'branch-' + steps.ref-sanitized.outputs.result }}
           label-custom: |
             org.opencontainers.image.vendor=zwave-js
             org.opencontainers.image.documentation=https://zwave-js.github.io/zwavejs2mqtt/#/

--- a/.github/workflows/docker-test-amd64.yml
+++ b/.github/workflows/docker-test-amd64.yml
@@ -27,7 +27,6 @@ jobs:
           images: zwavejs/zwavejs2mqtt
           tag-sha: false
           tag-latest: false
-          tag-custom: ${{ steps.ref-sanitized.outputs.result }}
           label-custom: |
             org.opencontainers.image.vendor=zwave-js
             org.opencontainers.image.documentation=https://zwave-js.github.io/zwavejs2mqtt/#/

--- a/.github/workflows/docker-test-amd64.yml
+++ b/.github/workflows/docker-test-amd64.yml
@@ -1,15 +1,9 @@
-name: Docker Build
+name: Docker Test linux/amd64
 
 on:
-  push:
-    branches:
-      - master
   pull_request:
     paths-ignore:
-      - 'docs/**'
-  release:
-    types:
-      - created
+      - "docs/**"
 
 jobs:
   build:
@@ -19,13 +13,17 @@ jobs:
 
       - uses: docker/setup-buildx-action@v1
       - uses: docker/setup-qemu-action@v1
-      - name: Login to dockerhub
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v1
+      - uses: actions/github-script@v3
+
+      - name: Sanitize github ref
+        id: ref-sanitized
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-      - id: docker_meta
+          script: |
+            const ref = context.ref
+            return ref.replace(/^refs\/heads\/|-/, '')
+
+      - name: Create Docker Meta
+        id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1
         with:
           images: zwavejs/zwavejs2mqtt
@@ -33,19 +31,13 @@ jobs:
           tag-latest: true
           tag-semver: |
             {{version}}
-          tag-custom: ${{ github.ref == 'refs/heads/master' && 'dev' || '' }}
+          tag-custom: "dev"
           label-custom: |
             org.opencontainers.image.vendor=zwave-js
             org.opencontainers.image.documentation=https://zwave-js.github.io/zwavejs2mqtt/#/
             org.opencontainers.image.authors=Daniel Lando <daniel.sorridi@gmail.com>
             org.opencontainers.image.url=https://zwave-js.github.io/zwavejs2mqtt/#/
             maintainer=robertsLando
-      - uses: actions/github-script@v3
-        id: ref-sanitized
-        with:
-          script: |
-            const ref = context.ref
-            return ref.replace(/^refs\/heads\/|-/, '')
 
       - name: Cache Docker layers
         uses: actions/cache@v2
@@ -57,13 +49,13 @@ jobs:
             buildx-${{ steps.ref-sanitized.outputs.result }}
             buildx-
 
-      - name: build+push
+      - name: Buildx build
         uses: docker/build-push-action@v2
         with:
-          platforms: linux/arm64,linux/amd64,linux/arm/v6,linux/arm/v7
+          # platforms: linux/arm64,linux/amd64,linux/arm/v6,linux/arm/v7
+          platforms: linux/amd64
           file: docker/Dockerfile
-          cache-from: type=local,mode=max,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache
-          push: ${{ github.event_name != 'pull_request' }}
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+          push: false
           tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/docker-test-amd64.yml
+++ b/.github/workflows/docker-test-amd64.yml
@@ -3,7 +3,7 @@ name: Docker Test linux/amd64
 on:
   pull_request:
     paths-ignore:
-      - "docs/**"
+      - 'docs/**'
 
 jobs:
   build:
@@ -27,11 +27,9 @@ jobs:
         uses: crazy-max/ghaction-docker-meta@v1
         with:
           images: zwavejs/zwavejs2mqtt
-          tag-sha: true
-          tag-latest: true
-          tag-semver: |
-            {{version}}
-          tag-custom: "dev"
+          tag-sha: false
+          tag-latest: false
+          tag-custom: 'branch-{{ steps.ref-sanitized.outputs.result }}'
           label-custom: |
             org.opencontainers.image.vendor=zwave-js
             org.opencontainers.image.documentation=https://zwave-js.github.io/zwavejs2mqtt/#/

--- a/.github/workflows/docker-test-amd64.yml
+++ b/.github/workflows/docker-test-amd64.yml
@@ -14,8 +14,6 @@ jobs:
       - uses: docker/setup-buildx-action@v1
       - uses: docker/setup-qemu-action@v1
       - uses: actions/github-script@v3
-
-      - name: Sanitize github ref
         id: ref-sanitized
         with:
           script: |

--- a/.github/workflows/docker-test-amd64.yml
+++ b/.github/workflows/docker-test-amd64.yml
@@ -27,7 +27,7 @@ jobs:
           images: zwavejs/zwavejs2mqtt
           tag-sha: false
           tag-latest: false
-          tag-custom: branch-${{ steps.ref-sanitized.outputs.result }}
+          tag-custom: ${{ steps.ref-sanitized.outputs.result }}
           label-custom: |
             org.opencontainers.image.vendor=zwave-js
             org.opencontainers.image.documentation=https://zwave-js.github.io/zwavejs2mqtt/#/

--- a/.github/workflows/docker-test-amd64.yml
+++ b/.github/workflows/docker-test-amd64.yml
@@ -3,7 +3,7 @@ name: Docker Test linux/amd64
 on:
   pull_request:
     paths-ignore:
-      - 'docs/**'
+      - "docs/**"
 
 jobs:
   build:
@@ -27,7 +27,7 @@ jobs:
           images: zwavejs/zwavejs2mqtt
           tag-sha: false
           tag-latest: false
-          tag-custom: 'branch-{{ steps.ref-sanitized.outputs.result }}'
+          tag-custom: "branch-${{ steps.ref-sanitized.outputs.result }}"
           label-custom: |
             org.opencontainers.image.vendor=zwave-js
             org.opencontainers.image.documentation=https://zwave-js.github.io/zwavejs2mqtt/#/

--- a/.github/workflows/docker-test-amd64.yml
+++ b/.github/workflows/docker-test-amd64.yml
@@ -27,7 +27,7 @@ jobs:
           images: zwavejs/zwavejs2mqtt
           tag-sha: false
           tag-latest: false
-          tag-custom: ${{ 'branch-' + steps.ref-sanitized.outputs.result }}
+          tag-custom: branch-${{ steps.ref-sanitized.outputs.result }}
           label-custom: |
             org.opencontainers.image.vendor=zwave-js
             org.opencontainers.image.documentation=https://zwave-js.github.io/zwavejs2mqtt/#/

--- a/.github/workflows/docker-test-arm64.yml
+++ b/.github/workflows/docker-test-arm64.yml
@@ -1,4 +1,4 @@
-name: Docker Test linux/amd64
+name: Docker Test linux/arm64
 
 on:
   pull_request:
@@ -47,7 +47,7 @@ jobs:
       - name: Buildx build
         uses: docker/build-push-action@v2
         with:
-          platforms: linux/amd64
+          platforms: linux/arm64
           file: docker/Dockerfile
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/docker-test-armv6.yml
+++ b/.github/workflows/docker-test-armv6.yml
@@ -1,4 +1,4 @@
-name: Docker Test linux/amd64
+name: Docker Test linux/arm/v6
 
 on:
   pull_request:
@@ -47,7 +47,7 @@ jobs:
       - name: Buildx build
         uses: docker/build-push-action@v2
         with:
-          platforms: linux/amd64
+          platforms: linux/arm/v6
           file: docker/Dockerfile
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/docker-test-armv7.yml
+++ b/.github/workflows/docker-test-armv7.yml
@@ -1,4 +1,4 @@
-name: Docker Test linux/amd64
+name: Docker Test linux/arm/v7
 
 on:
   pull_request:
@@ -47,7 +47,7 @@ jobs:
       - name: Buildx build
         uses: docker/build-push-action@v2
         with:
-          platforms: linux/amd64
+          platforms: linux/arm/v7
           file: docker/Dockerfile
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache


### PR DESCRIPTION
The idea behind this is to improve docker builds speed by splitting actual dockerbuild workflow in 5 different workflows: 

- 4 workflows one for each arch for PR tests (no push to docker): linux/arm64,linux/amd64,linux/arm/v6,linux/arm/v7
- 1 workflow that runs on release created and on push to master that works like it is now builds all the images needed and push them to dockerhub