### PR TITLE
chore(deps): bump @zwave-js/server from 1.0.0 to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3968,9 +3968,9 @@
       }
     },
     "@zwave-js/server": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@zwave-js/server/-/server-1.0.0.tgz",
-      "integrity": "sha512-VwkAxqA+fSi5Mc696E7OUFD3670Zun5GRiKIR+2cDLaZBeowf9azl3u+fGaok62+N34iatB8O4ahJOWSvZj+HA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@zwave-js/server/-/server-1.1.0.tgz",
+      "integrity": "sha512-2NDCwWJCR9nnDsuLyEud5w0rmoMq7ZwLcuadZ2uWhADhNHxk9bBfa7uIsyCaYYV/8MiKZ6iPtjIA+Y7ey2BrWA==",
       "requires": {
         "minimist": "^1.2.5",
         "ws": "^7.4.2"

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
   },
   "dependencies": {
     "@babel/polyfill": "^7.12.1",
-    "@zwave-js/server": "^1.0.0",
+    "@zwave-js/server": "^1.1.0",
     "ansi_up": "^5.0.0",
     "app-root-path": "^3.0.0",
     "archiver": "^5.2.0",


### PR DESCRIPTION
This version introduces a new schema versioning system to support backwards compatibility