### PR TITLE
chore: k8s deployment CR formatting

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -140,8 +140,8 @@ spec:
           path: /dev/ttyACM0
           type: File
       - name: data
-          hostPath:
-            path: /zwave/data
+        hostPath:
+          path: /zwave/data
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Too many spaces, invalid yaml