### PR TITLE
fix: show hex number along with the `unknown` strings

### DIFF
--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -866,10 +866,18 @@ function initNode (zwaveNode) {
 
   const node = this.nodes.get(nodeId)
 
+  const hexIds = [
+    utils.num2hex(zwaveNode.manufacturerId),
+    utils.num2hex(zwaveNode.productId),
+    utils.num2hex(zwaveNode.productType)
+  ]
+  node.hexId = `${hexIds[0]}-${hexIds[2]}-${hexIds[1]}`
+  node.dbLink = `https://devices.zwave-js.io/?jumpTo=${hexIds[0]}:${hexIds[2]}:${hexIds[1]}:${node.firmwareVersion}`
+
   const deviceConfig = zwaveNode.deviceConfig || {
-    label: 'Unknown product ' + utils.num2hex(zwaveNode.productId),
-    description: utils.num2hex(zwaveNode.productType),
-    manufacturer: 'Unknown manufacturer ' + utils.num2hex(zwaveNode.manufacturerId)
+    label: `Unknown product ${hexIds[1]}`,
+    description: hexIds[2],
+    manufacturer: `Unknown manufacturer ${hexIds[0]}`
   }
 
   const deviceClass = zwaveNode.deviceClass || {
@@ -927,14 +935,6 @@ function initNode (zwaveNode) {
   }
 
   node.deviceId = getDeviceID(node)
-
-  const hexIds = [
-    utils.num2hex(node.manufacturerId),
-    utils.num2hex(node.productId),
-    utils.num2hex(node.productType)
-  ]
-  node.hexId = `${hexIds[0]}-${hexIds[2]}-${hexIds[1]}`
-  node.dbLink = `https://devices.zwave-js.io/?jumpTo=${hexIds[0]}:${hexIds[2]}:${hexIds[1]}:${node.firmwareVersion}`
 
   this.getGroups(zwaveNode.id, true)
 }

--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -867,9 +867,9 @@ function initNode (zwaveNode) {
   const node = this.nodes.get(nodeId)
 
   const deviceConfig = zwaveNode.deviceConfig || {
-    label: 'Unknown product 0x' + parseInt(zwaveNode.productId).toString(16),
-    description: zwaveNode.productType,
-    manufacturer: 'Unknown manufacturer 0x' + parseInt(zwaveNode.manufacturerId).toString(16)
+    label: 'Unknown product ' + utils.num2hex(zwaveNode.productId),
+    description: utils.num2hex(zwaveNode.productType),
+    manufacturer: 'Unknown manufacturer ' + utils.num2hex(zwaveNode.manufacturerId)
   }
 
   const deviceClass = zwaveNode.deviceClass || {

--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -867,9 +867,9 @@ function initNode (zwaveNode) {
   const node = this.nodes.get(nodeId)
 
   const deviceConfig = zwaveNode.deviceConfig || {
-    label: 'Unknown product ' + parseInt(zwaveNode.productId).toString(16),
+    label: 'Unknown product 0x' + parseInt(zwaveNode.productId).toString(16),
     description: zwaveNode.productType,
-    manufacturer: 'Unknown manufacturer ' + parseInt(zwaveNode.manufacturerId).toString(16)
+    manufacturer: 'Unknown manufacturer 0x' + parseInt(zwaveNode.manufacturerId).toString(16)
   }
 
   const deviceClass = zwaveNode.deviceClass || {

--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -867,9 +867,9 @@ function initNode (zwaveNode) {
   const node = this.nodes.get(nodeId)
 
   const deviceConfig = zwaveNode.deviceConfig || {
-    label: 'Unknown product ' + zwaveNode.productId,
+    label: 'Unknown product ' + parseInt(zwaveNode.productId).toString(16),
     description: zwaveNode.productType,
-    manufacturer: 'Unknown manufacturer ' + zwaveNode.manufacturerId
+    manufacturer: 'Unknown manufacturer ' + parseInt(zwaveNode.manufacturerId).toString(16)
   }
 
   const deviceClass = zwaveNode.deviceClass || {


### PR DESCRIPTION
The accepted convention for representing manufacturer and product identifiers appears to use hexadecimal.