### PR TITLE
fix(hass): remove `state_topic` on covers for HA 2020.3.2

### DIFF
--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -1695,7 +1695,6 @@ Gateway.prototype.discoverValue = function (node, vId) {
             ].includes(specificDeviceClass)
           ) {
             cfg = copy(hassCfg.cover_position)
-            cfg.discovery_payload.state_topic = getTopic
             cfg.discovery_payload.command_topic = setTopic
             cfg.discovery_payload.position_topic = getTopic
             cfg.discovery_payload.set_position_topic =

--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -1699,7 +1699,7 @@ Gateway.prototype.discoverValue = function (node, vId) {
             cfg.discovery_payload.position_topic = getTopic
             cfg.discovery_payload.set_position_topic =
               cfg.discovery_payload.command_topic
-            cfg.discovery_payload.value_template =
+            cfg.discovery_payload.position_template =
               '{{ value_json.value | round(0) }}'
             cfg.discovery_payload.position_open = 99
             cfg.discovery_payload.position_closed = 0


### PR DESCRIPTION
Home assistant fixed a behaviour on MQTT Covers. we need to remove state_topic, as it breaks the use of MQTT Cover

Fixes #830 