### PR TITLE
fix: use prefixed node.id in mqtt discovery topic

### DIFF
--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -676,8 +676,10 @@ function deviceInfo (node, nodeName) {
  * @param {string} nodeName Node name from getNodeName function
  * @returns The topic string for this device discovery
  */
-function getDiscoveryTopic (hassDevice, nodeName) {
-  return `${hassDevice.type}/${nodeName}/${hassDevice.object_id}/config`
+function getDiscoveryTopic (hassDevice, nodeId) {
+  return `${hassDevice.type}/${NODE_PREFIX + nodeId}/${
+    hassDevice.object_id
+  }/config`
 }
 
 /**
@@ -1456,7 +1458,7 @@ Gateway.prototype.discoverDevice = function (node, hassDevice) {
           '_' +
           hassDevice.object_id
 
-        const discoveryTopic = getDiscoveryTopic(hassDevice, nodeName)
+        const discoveryTopic = getDiscoveryTopic(hassDevice, node.id)
         hassDevice.discoveryTopic = discoveryTopic
 
         // This configuration is not stored in nodes.json
@@ -2157,7 +2159,7 @@ Gateway.prototype.discoverValue = function (node, vId) {
       '_' +
       utils.sanitizeTopic(valueId.id, true)
 
-    const discoveryTopic = getDiscoveryTopic(cfg, nodeName)
+    const discoveryTopic = getDiscoveryTopic(cfg, node.id)
 
     cfg.discoveryTopic = discoveryTopic
     cfg.values = cfg.values || []


### PR DESCRIPTION
If spaces are used within the node name, the mqtt discovery topic contains spaces as well.
This is not supported by a lot of MQTT clients, like homeassistant.