### PR TITLE
fix: revert PR #920 "use prefixed node.id in mqtt discovery topic"

### DIFF
--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -668,10 +668,8 @@ function deviceInfo (node, nodeName) {
  * @param {string} nodeName Node name from getNodeName function
  * @returns The topic string for this device discovery
  */
-function getDiscoveryTopic (hassDevice, nodeId) {
-  return `${hassDevice.type}/${NODE_PREFIX + nodeId}/${
-    hassDevice.object_id
-  }/config`
+function getDiscoveryTopic (hassDevice, nodeName) {
+  return `${hassDevice.type}/${nodeName}/${hassDevice.object_id}/config`
 }
 
 /**
@@ -1450,7 +1448,7 @@ Gateway.prototype.discoverDevice = function (node, hassDevice) {
           '_' +
           hassDevice.object_id
 
-        const discoveryTopic = getDiscoveryTopic(hassDevice, node.id)
+        const discoveryTopic = getDiscoveryTopic(hassDevice, nodeName)
         hassDevice.discoveryTopic = discoveryTopic
 
         // This configuration is not stored in nodes.json
@@ -2151,7 +2149,7 @@ Gateway.prototype.discoverValue = function (node, vId) {
       '_' +
       utils.sanitizeTopic(valueId.id, true)
 
-    const discoveryTopic = getDiscoveryTopic(cfg, node.id)
+    const discoveryTopic = getDiscoveryTopic(cfg, nodeName)
 
     cfg.discoveryTopic = discoveryTopic
     cfg.values = cfg.values || []


### PR DESCRIPTION
This reverts PR #920 