### PR TITLE
fix(ui): use transparent background on zwave graph groups

### DIFF
--- a/src/components/custom/ZwaveGraph.vue
+++ b/src/components/custom/ZwaveGraph.vue
@@ -205,7 +205,7 @@ svg > .output {
 
 .cluster > rect {
   stroke: lightgray;
-  fill: #f8f8f8;
+  fill: transparent;
   stroke-width: 1px;
   stroke-linecap: round;
 }


### PR DESCRIPTION
![Schermata da 2021-04-07 11-02-57](https://user-images.githubusercontent.com/11502495/113841873-77735a80-9792-11eb-98f3-922b6641c341.png)
![Schermata da 2021-04-07 11-03-04](https://user-images.githubusercontent.com/11502495/113841876-780bf100-9792-11eb-8e52-cb3525cc8986.png)
