### PR TITLE
fix(hass): sending `true` to MultilevelSwitchCC doesn't restore old level

### DIFF
--- a/lib/Gateway.js
+++ b/lib/Gateway.js
@@ -969,7 +969,7 @@ Gateway.prototype.parsePayload = function (payload, valueId, valueConf) {
 
     // on/off becomes 100%/0%
     if (typeof payload === 'boolean' && valueId.type === 'number') {
-      payload = payload ? valueId.max : valueId.min
+      payload = payload ? 0xff : valueId.min
     }
 
     if (valueId.commandClass === CommandClasses['Binary Toggle Switch']) {


### PR DESCRIPTION
Fixes #1132 