### PR TITLE
feat(docker): push image to ghcr

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -21,10 +21,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
       - id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1
         with:
-          images: zwavejs/zwavejs2mqtt
+          images: zwavejs/zwavejs2mqtt,ghcr.io/zwavejs/zwavejs2mqtt
           tag-sha: true
           tag-latest: true
           tag-semver: |

--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -25,8 +25,8 @@ jobs:
         uses: docker/login-action@v1
         with:
           registry: ghcr.io
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1
         with:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -23,11 +23,18 @@ jobs:
             const ref = context.ref
             return ref.replace(/^refs\/heads\/|-/, '')
 
+      - name: Login to GHCR
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ secrets.GHCR_USERNAME }}
+          password: ${{ secrets.GHCR_TOKEN }}
+
       - name: Create Docker Meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1
         with:
-          images: zwavejs/zwavejs2mqtt
+          images: zwavejs/zwavejs2mqtt,ghcr.io/zwavejs/zwavejs2mqtt
           tag-sha: false
           tag-latest: false
           label-custom: |

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -23,18 +23,11 @@ jobs:
             const ref = context.ref
             return ref.replace(/^refs\/heads\/|-/, '')
 
-      - name: Login to GHCR
-        uses: docker/login-action@v1
-        with:
-          registry: ghcr.io
-          username: ${{ secrets.GHCR_USERNAME }}
-          password: ${{ secrets.GHCR_TOKEN }}
-
       - name: Create Docker Meta
         id: docker_meta
         uses: crazy-max/ghaction-docker-meta@v1
         with:
-          images: zwavejs/zwavejs2mqtt,ghcr.io/zwavejs/zwavejs2mqtt
+          images: zwavejs/zwavejs2mqtt
           tag-sha: false
           tag-latest: false
           label-custom: |


### PR DESCRIPTION
👋🏼 Hi @robertsLando here's a PR to publish the Docker image to Github container registry and keeps dockerhub.

The reason for this is Dockerhub has pretty serious rate limits (100 per 6 hours). Having and additional Docker registry would be awesome and it's so simple with GHCR.

This change requires a PAT being created and secrets in teh repo settings for:

- `GHCR_USERNAME`
- `GHCR_TOKEN`

After the image is pushed you will need to make the image public in the Github package.

Thanks for the consideration, hoping you find this useful.