### PR TITLE
Add workaround for duration support on sendCommand set

### DIFF
--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -2664,7 +2664,7 @@ ZwaveClient.prototype.sendCommand = async function (ctx, command, args) {
       )
     }
 
-    if (command == "set" && args.length > 1 && !isNaN(args[1])) {
+    if (command === "set" && args.length > 1 && !isNaN(args[1])) {
         // Set command supports a duration as the second argument, which JSON does not support, 
         // so we convert a number of seconds to a Duration object
         args[1] = new Duration(args[1], "seconds");

--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -2664,6 +2664,12 @@ ZwaveClient.prototype.sendCommand = async function (ctx, command, args) {
       )
     }
 
+    if (command == "set" && args.length > 1 && !isNaN(args[1])) {
+        // Set command supports a duration as the second argument, which JSON does not support, 
+        // so we convert a number of seconds to a Duration object
+        args[1] = new Duration(args[1], "seconds");
+    }
+
     // send the command with args
     const method = api[command].bind(api)
     const result = args ? await method(...args) : await method()


### PR DESCRIPTION
This is a workaround for https://github.com/zwave-js/node-zwave-js/issues/1321 that allows setting MultiLevelSwitch with duration parameter via `sendCommand` mqtt topic by specifying second parameter in the `set` command as duration seconds.

This is not ideal, but it allows us to at least use dimming duration in some way until proper solution is developed (which appears to take a while).