### PR TITLE
fix: allow `sendCommand` to accept string command classes

### DIFF
--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -1425,7 +1425,7 @@ class ZwaveClient extends EventEmitter {
   /**
    * Send a command
    *
-   * @param {{nodeId: number, endpoint: number, commandClass: number}} ctx context to get the instance to send the command
+   * @param {{nodeId: number, endpoint: number, commandClass: number | string}} ctx context to get the instance to send the command
    * @param {string} command command name
    * @param {any[]} args args to pass to `command`
    * @returns {Promise<any>}
@@ -1454,8 +1454,12 @@ class ZwaveClient extends EventEmitter {
         )
       }
 
+      const commandClass = isNaN(ctx.commandClass)
+        ? CommandClasses[ctx.commandClass]
+        : ctx.commandClass
+
       // get the command class instance to send the command
-      const api = endpoint.commandClasses[ctx.commandClass]
+      const api = endpoint.commandClasses[commandClass]
       if (!api || !api.isSupported()) {
         throw Error(
           `Node ${ctx.nodeId} (Endpoint ${ctx.endpoint}) does not support CC ${ctx.commandClass} or it has not been implemented yet`

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -416,7 +416,7 @@ export interface ZwaveClient extends EventEmitter {
   ): Promise<void>
   writeValue(valueId: Z2MValueId, value: unknown): Promise<void>
   sendCommand(
-    ctx: { nodeId: number; endpoint: number; commandClass: number },
+    ctx: { nodeId: number; endpoint: number; commandClass: number | string },
     command: string,
     args: any[]
   ): Promise<any>


### PR DESCRIPTION
Fixes #1219