### PR TITLE
docs: update quick-start

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -52,6 +52,8 @@ sudo snap connect zwavejs2mqtt:hardware-observe
 
 > [!NOTE]
 > See `zwavejs2mqtt.help` for usage and environment settings.
+> 
+> Raspberry Pi users running Rasbian/Debian, read [this thread](https://github.com/zwave-js/zwavejs2mqtt/discussions/1216#discussion-3364776). Please ask Rasbian/Debian related-questions in this thread.
 
 ## NodeJS or PKG version
 

--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -52,7 +52,7 @@ sudo snap connect zwavejs2mqtt:hardware-observe
 
 > [!NOTE]
 > See `zwavejs2mqtt.help` for usage and environment settings.
-> 
+>
 > Raspberry Pi users running Rasbian/Debian, read [this thread](https://github.com/zwave-js/zwavejs2mqtt/discussions/1216#discussion-3364776). Please ask Rasbian/Debian related-questions in this thread.
 
 ## NodeJS or PKG version


### PR DESCRIPTION
Add information about using the snap package under Rasbian/Debian as it requires some system modifications that is not common and cant be changed from the Snap-package.