### PR TITLE
fix: change default zwavejs log file name

### DIFF
--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -87,7 +87,7 @@ const allowedApis = [
   'restart'
 ]
 
-const ZWAVEJS_LOG_FILE = utils.joinPath(storeDir, `zwavejs_${process.pid}.log`)
+const ZWAVEJS_LOG_FILE = utils.joinPath(storeDir, 'zwavejs_%DATE%.log')
 
 /**
  * The constructor


### PR DESCRIPTION
It's now `zwavejs_%DATE%.log` after introducing log rotation