### PR TITLE
fix: put deviceConfigPriorityDir where it belongs

### DIFF
--- a/lib/ZwaveClient.js
+++ b/lib/ZwaveClient.js
@@ -732,7 +732,8 @@ class ZwaveClient extends EventEmitter {
       const zwaveOptions = Object.assign(
         {
           storage: {
-            cacheDir: storeDir
+            cacheDir: storeDir,
+            deviceConfigPriorityDir: storeDir + '/config'
           },
           networkKey: this.cfg.networkKey,
           logConfig: {
@@ -746,8 +747,7 @@ class ZwaveClient extends EventEmitter {
               this.cfg.nodeFilter && this.cfg.nodeFilter.length > 0
                 ? this.cfg.nodeFilter.map(n => parseInt(n))
                 : undefined
-          },
-          deviceConfigPriorityDir: storeDir + '/config'
+          }
         },
         this.cfg.options
       )


### PR DESCRIPTION
fixes: https://github.com/zwave-js/zwavejs2mqtt/issues/1223

@robertsLando can I interest you in some TypeScript to avoid this kind of stuff? 😅