### PR TITLE
fix: plugins router must be recreated on restart

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -107,9 +107,11 @@ socketManager.authMiddleware = function (
 
 let gw: Gateway // the gateway instance
 const plugins = [] as CustomPlugin[]
-const pluginsRouter = express.Router()
+let pluginsRouter
 
-app.use(pluginsRouter)
+app.use(function (req, res, next) {
+	pluginsRouter(req, res, next)
+})
 
 // flag used to prevent multiple restarts while one is already in progress
 let restarting = false
@@ -277,6 +279,7 @@ async function startGateway(settings: Settings) {
 	await gw.start()
 
 	const pluginsConfig = settings.gateway?.plugins ?? null
+	pluginsRouter = express.Router()
 
 	// load custom plugins
 	if (pluginsConfig && Array.isArray(pluginsConfig)) {

--- a/app.ts
+++ b/app.ts
@@ -109,10 +109,6 @@ let gw: Gateway // the gateway instance
 const plugins = [] as CustomPlugin[]
 let pluginsRouter
 
-app.use(function (req, res, next) {
-	pluginsRouter(req, res, next)
-})
-
 // flag used to prevent multiple restarts while one is already in progress
 let restarting = false
 
@@ -422,6 +418,10 @@ app.use(
 		},
 	})
 )
+
+app.use(function (req, res, next) {
+	pluginsRouter(req, res, next)
+})
 
 // Node.js CSRF protection middleware.
 // Requires either a session middleware or cookie-parser to be initialized first.


### PR DESCRIPTION
expressjs is using static config, but we have option to restart plugins without restarting the whole service (when restarting zwave after applying settings). Plugin will fail (silently) to register expressjs handler after such restart.

Problem may be tested with the following plugin:

```
class TestPlugin {
  constructor(ctx) {
    this.zwave = ctx.zwave
    this.mqtt = ctx.mqtt
    this.logger = ctx.logger
    this.app = ctx.app

    var text = new Date().toString()

    this.logger.info(`Starting at: ${text}`)

    this.app.get('/test', function(req, res) {
      res.send(`Started at: ${text}`)
    })
  }

  async destroy() {
    this.logger.info('Stopped')
  }
}

module.exports = function(ctx) {
  return new TestPlugin(ctx)
}
```

* Start zwavejs2mqgg, curl to `/test`.
* Go to settings page and click 'Save'
* curl to '/test' and you will see old message insteadof new