### PR TITLE
chore(docker): yarn fails to install plugins

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -52,6 +52,7 @@ RUN apk add --no-cache \
     tzdata \	
     eudev	
 
+
 # Copy files from previous build stage	
 COPY --from=build-z2m /usr/src/app /usr/src/app
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -29,7 +29,7 @@ RUN yarn run build && \
 # add plugin support, space separated
 ARG plugins
 RUN if [ ! -z "$plugins" ]; \
-    then echo "Installing plugins ${plugins}"; yarn install ${plugins} ; fi
+    then echo "Installing plugins ${plugins}"; yarn add ${plugins} ; fi
 
 # when update devices arg is set update config files from zwavejs repo
 ARG updateDevices


### PR DESCRIPTION
Yarn add needs to be used for plugin installs, otherwise it will not
work.
 by this addition we fix this issue