### PR TITLE
fix(hass): make dimmers turn on to previous brightness

### DIFF
--- a/hass/configurations.ts
+++ b/hass/configurations.ts
@@ -55,10 +55,9 @@ const configurations: Record<HassDeviceKey, HassDevice> = {
 			state_topic: true,
 			command_topic: true,
 			on_command_type: 'last',
-      payload_on: 255,
-      payload_off: 0,
-			state_value_template:
-				'{{ 0 if value_json.value == 0 else 255 }}',
+			payload_on: 255,
+			payload_off: 0,
+			state_value_template: '{{ 0 if value_json.value == 0 else 255 }}',
 			brightness_value_template: '{{ value_json.value }}',
 			brightness_scale: 99,
 			rgb_command_template:
@@ -73,15 +72,14 @@ const configurations: Record<HassDeviceKey, HassDevice> = {
 		discovery_payload: {
 			command_topic: true,
 			state_topic: true,
-			state_value_template:
-				'{{ 0 if value_json.value == 0 else 255 }}',
+			state_value_template: '{{ 0 if value_json.value == 0 else 255 }}',
 			brightness_command_topic: true,
 			brightness_scale: 99,
 			brightness_state_topic: true,
 			brightness_value_template: '{{ value_json.value }}',
 			on_command_type: 'last',
-      payload_on: 255,
-      payload_off: 0,
+			payload_on: 255,
+			payload_off: 0,
 		},
 	},
 	volume_dimmer: {

--- a/hass/configurations.ts
+++ b/hass/configurations.ts
@@ -54,9 +54,11 @@ const configurations: Record<HassDeviceKey, HassDevice> = {
 		discovery_payload: {
 			state_topic: true,
 			command_topic: true,
-			on_command_type: 'brightness',
+			on_command_type: 'last',
+      payload_on: 255,
+      payload_off: 0,
 			state_value_template:
-				'{{ "OFF" if value_json.value == 0 else "ON" }}',
+				'{{ 0 if value_json.value == 0 else 255 }}',
 			brightness_value_template: '{{ value_json.value }}',
 			brightness_scale: 99,
 			rgb_command_template:
@@ -72,12 +74,14 @@ const configurations: Record<HassDeviceKey, HassDevice> = {
 			command_topic: true,
 			state_topic: true,
 			state_value_template:
-				'{{ "OFF" if value_json.value == 0 else "ON" }}',
+				'{{ 0 if value_json.value == 0 else 255 }}',
 			brightness_command_topic: true,
 			brightness_scale: 99,
 			brightness_state_topic: true,
 			brightness_value_template: '{{ value_json.value }}',
-			on_command_type: 'brightness',
+			on_command_type: 'last',
+      payload_on: 255,
+      payload_off: 0,
 		},
 	},
 	volume_dimmer: {


### PR DESCRIPTION
This fixes a side-effect from the changes in zwave-js/zwavejs2mqtt/pull/290 that caused using the toggle to turn a dimmer on to make the light come on at full brightness instead of restoring the previous level (see discussion at end of #294). While there might be an argument for that as intentional behavior, this change also brings the behavior over MQTT in line with the behavior when using the direct ZwaveJS integration (where Zwave dimmers return to their previous brightness when the toggle is used).

The only caveat I can find in my testing is a very slight but noticeable delay on the brightness slider updating, because HA isn't sending a brightness so it doesn't preemptively move the slider.