### PR TITLE
feat: add option to writeValue api

### DIFF
--- a/lib/Gateway.ts
+++ b/lib/Gateway.ts
@@ -7,7 +7,7 @@
 import * as fs from 'fs'
 import * as path from 'path'
 import * as utils from '../lib/utils'
-import { AlarmSensorType } from 'zwave-js'
+import { AlarmSensorType, SetValueAPIOptions } from 'zwave-js'
 import { CommandClasses, ValueID } from '@zwave-js/core'
 import { socketEvents } from '../lib/SocketManager'
 import * as Constants from './Constants'
@@ -1974,7 +1974,7 @@ export default class Gateway {
 	 */
 	private async _onBroadRequest(
 		parts: string[],
-		payload: ValueID & { value: unknown }
+		payload: ValueID & { value: unknown; options?: SetValueAPIOptions }
 	): Promise<void> {
 		if (parts.length > 0) {
 			// multiple writes (back compatibility mode)
@@ -1992,7 +1992,8 @@ export default class Gateway {
 				for (let i = 0; i < values.length; i++) {
 					await this._zwave.writeValue(
 						this.topicValues[values[i]],
-						payload
+						payload,
+						payload?.options
 					)
 				}
 			}
@@ -2025,7 +2026,7 @@ export default class Gateway {
 
 		if (valueId) {
 			payload = this.parsePayload(payload, valueId, valueId.conf)
-			await this._zwave.writeValue(valueId, payload)
+			await this._zwave.writeValue(valueId, payload, payload?.options)
 		}
 	}
 

--- a/lib/ZwaveClient.ts
+++ b/lib/ZwaveClient.ts
@@ -32,6 +32,7 @@ import {
 	ZWavePlusNodeType,
 	ZWavePlusRoleType,
 	ZWaveError,
+	SetValueAPIOptions,
 } from 'zwave-js'
 import {
 	CommandClasses,
@@ -1890,7 +1891,11 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	/**
 	 * Set a value of a specific zwave valueId
 	 */
-	async writeValue(valueId: Z2MValueId, value: any) {
+	async writeValue(
+		valueId: Z2MValueId,
+		value: any,
+		options?: SetValueAPIOptions
+	) {
 		if (this.driverReady) {
 			const vID = this._getValueID(valueId, true)
 			logger.log('info', `Writing %o to ${vID}`, value)
@@ -1942,7 +1947,8 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 				} else {
 					result = await this.getNode(valueId.nodeId).setValue(
 						valueId,
-						value
+						value,
+						options
 					)
 					this.emit('valueWritten', valueId, value)
 				}


### PR DESCRIPTION
Fixes #1367. When payload type is set to JSON or Zwave ValueId write requests (topics with `/set` suffix) can contain `options` oobject in payload and them will be used as options in `setValue` call