### PR TITLE
fix: change the GE/Jasco 14314 to use the fan dimmer hass discovery

### DIFF
--- a/hass/devices.ts
+++ b/hass/devices.ts
@@ -342,6 +342,8 @@ const devices: { [deviceId: string]: HassDevice[] } = {
 	'57-12593-18756': [FAN_DIMMER], // Honeywell 39358 In-Wall Fan Control
 	'99-12340-18756': [FAN_DIMMER], // GE 1724 Dimmer
 	'99-12593-18756': [FAN_DIMMER], // GE 1724 Dimmer
+	'99-12600-18756': [FAN_DIMMER], // GE 14314 Dimmer (Older variant)
+	'99-12850-18756': [FAN_DIMMER], // GE 14314 Dimmer (Newer variant coming with FW 5.22)
 	'152-12-25857': [THERMOSTAT_2GIG], // Radio Thermostat / 2GIG CT101
 	'152-263-25601': [THERMOSTAT_2GIG], // Radio Thermostat / 2GIG CT100
 	'152-256-8194': [THERMOSTAT_2GIG], // Radio Thermostat / 2GIG CT32


### PR DESCRIPTION
I've got a couple of the GE 14314 with the older firmware (i.e. the 12600 product id). But figured while I was at it I should also add 12850 which should be newer variants per the [zwave alliance data](https://products.z-wavealliance.org/Search/Index?regionId=2&searchText=14314). You will see there are 3 variants registered as 14314. 2 of which share the `12600` (i.e. ` 0x3138` hex encoded) product id and 1 has `12850` (i.e. `0x3232` hex encoded).