### PR TITLE
feat: add `MQTT_NAME` env var

### DIFF
--- a/docs/guide/env-vars.md
+++ b/docs/guide/env-vars.md
@@ -10,6 +10,7 @@ This is the list of the actually supported env vars:
 - `HOST`: The host address to bind to. Default is `0.0.0.0`
 - `STORE_DIR`: The absolute path to the directory where all files will be stored. Default is `<path to your z2m dir>/store`
 - `ZWAVEJS_EXTERNAL_CONFIG`: Mostly needed for docker users, it's the path to the folder used by zwave-js to [store config database](https://zwave-js.github.io/node-zwave-js/#/usage/external-config?id=specifying-an-external-config-db-location), by default on docker image it is `/usr/src/app/store/.config-db`. For users that are using a custom `STORE_DIR` this must be changed too
+- `MQTT_NAME`: The name used as client name when connecting to the mqtt server. Overrides `mqtt.name` in `settings.json`
 
 This env vars can be used when running webpack dev server with HMR (most users will not need them):
 

--- a/hass/devices.ts
+++ b/hass/devices.ts
@@ -342,6 +342,8 @@ const devices: { [deviceId: string]: HassDevice[] } = {
 	'57-12593-18756': [FAN_DIMMER], // Honeywell 39358 In-Wall Fan Control
 	'99-12340-18756': [FAN_DIMMER], // GE 1724 Dimmer
 	'99-12593-18756': [FAN_DIMMER], // GE 1724 Dimmer
+	'99-12600-18756': [FAN_DIMMER], // GE 14314 Dimmer (Older variant)
+	'99-12850-18756': [FAN_DIMMER], // GE 14314 Dimmer (Newer variant coming with FW 5.22)
 	'152-12-25857': [THERMOSTAT_2GIG], // Radio Thermostat / 2GIG CT101
 	'152-263-25601': [THERMOSTAT_2GIG], // Radio Thermostat / 2GIG CT100
 	'152-256-8194': [THERMOSTAT_2GIG], // Radio Thermostat / 2GIG CT32

--- a/lib/MqttClient.ts
+++ b/lib/MqttClient.ts
@@ -245,7 +245,9 @@ class MqttClient extends TypedEventEmitter<MqttClientEventCallbacks> {
 			return
 		}
 
-		this._clientID = sanitizeTopic(MqttClient.NAME_PREFIX + (process.env.MQTT_NAME || config.name))
+		this._clientID = sanitizeTopic(
+			MqttClient.NAME_PREFIX + (process.env.MQTT_NAME || config.name)
+		)
 
 		const parsed = url.parse(config.host || '')
 		let protocol = 'mqtt'

--- a/lib/MqttClient.ts
+++ b/lib/MqttClient.ts
@@ -245,7 +245,7 @@ class MqttClient extends TypedEventEmitter<MqttClientEventCallbacks> {
 			return
 		}
 
-		this._clientID = sanitizeTopic(MqttClient.NAME_PREFIX + config.name)
+		this._clientID = sanitizeTopic(MqttClient.NAME_PREFIX + (process.env.MQTT_NAME || config.name))
 
 		const parsed = url.parse(config.host || '')
 		let protocol = 'mqtt'


### PR DESCRIPTION
I added the option to configure the mqtt name using an env variable. 

I needed this in order to manage several pods in a kubernetes cluster. 