### PR TITLE
fix: catch "controller not ready" error in statistics event handler

### DIFF
--- a/lib/ZwaveClient.ts
+++ b/lib/ZwaveClient.ts
@@ -2100,7 +2100,13 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	}
 
 	private _onControllerStatisticsUpdated(stats: ControllerStatistics) {
-		const controllerNode = this.nodes.get(this.driver.controller.ownNodeId)
+		let controllerNode: Z2MNode
+		try {
+			controllerNode = this.nodes.get(this.driver.controller.ownNodeId)
+		} catch (e) {
+			// This should not happen, but it does. Don't crash!
+			return
+		}
 
 		if (controllerNode) {
 			controllerNode.statistics = stats


### PR DESCRIPTION
For some reason, the controller no longer exists after its event handler is invoked.
I don't know why this happens. It should not, but it does and it bombs sentry with errors.