### PR TITLE
chore: bump zwave-js to 8.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "vuetify": "^2.5.3",
     "vuex": "^3.6.2",
     "winston": "^3.3.3",
-    "zwave-js": "^8.0.8"
+    "zwave-js": "^8.1.1"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1323,82 +1323,82 @@
     conventional-recommended-bump "^6.1.0"
     prepend-file "^2.0.0"
 
-"@sentry/core@6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.10.0.tgz#70af9dc72bb6a5b59062a31b7de023f7f1878357"
-  integrity sha512-5KlxHJlbD7AMo+b9pMGkjxUOfMILtsqCtGgI7DMvZNfEkdohO8QgUY+hPqr540kmwArFS91ipQYWhqzGaOhM3Q==
+"@sentry/core@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.11.0.tgz#40e94043afcf6407a109be26655c77832c64e740"
+  integrity sha512-09TB+f3pqEq8LFahFWHO6I/4DxHo+NcS52OkbWMDqEi6oNZRD7PhPn3i14LfjsYVv3u3AESU8oxSEGbFrr2UjQ==
   dependencies:
-    "@sentry/hub" "6.10.0"
-    "@sentry/minimal" "6.10.0"
-    "@sentry/types" "6.10.0"
-    "@sentry/utils" "6.10.0"
+    "@sentry/hub" "6.11.0"
+    "@sentry/minimal" "6.11.0"
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
     tslib "^1.9.3"
 
-"@sentry/hub@6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.10.0.tgz#d59be18016426fd3a5e8d38712c2080466aafe3c"
-  integrity sha512-MV8wjhWiFAXZAhmj7Ef5QdBr2IF93u8xXiIo2J+dRZ7eVa4/ZszoUiDbhUcl/TPxczaw4oW2a6tINBNFLzXiig==
+"@sentry/hub@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.11.0.tgz#ddf9ddb0577d1c8290dc02c0242d274fe84d6c16"
+  integrity sha512-pT9hf+ZJfVFpoZopoC+yJmFNclr4NPqPcl2cgguqCHb69DklD1NxgBNWK8D6X05qjnNFDF991U6t1mxP9HrGuw==
   dependencies:
-    "@sentry/types" "6.10.0"
-    "@sentry/utils" "6.10.0"
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
     tslib "^1.9.3"
 
-"@sentry/integrations@^6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-6.10.0.tgz#f8f9e7efd55ec44d0408bd4493df1c9ceabaaa63"
-  integrity sha512-NMtB0jjFYFZRxyjYu2dWLThk9YPIwqhi4hYywmWkbv4/ILzi5Rwnh+aqNW6yrj8qG4b9itNMh3YvEzmf0aqauw==
+"@sentry/integrations@^6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/integrations/-/integrations-6.11.0.tgz#da0706306b5ff13eaae5771095d7fc82c9f4c68b"
+  integrity sha512-CtSMW+PJlw+EunDJ+9LCWxRcXQIsUDlcUZOhFyAdmM5YIbg2V0IqHtnYg8X2sSGRO3aTEc7lOG5nF4lqr3R0yg==
   dependencies:
-    "@sentry/types" "6.10.0"
-    "@sentry/utils" "6.10.0"
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
     localforage "^1.8.1"
     tslib "^1.9.3"
 
-"@sentry/minimal@6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.10.0.tgz#9404b93fae649b6c48e1da8f0991b87cf9999561"
-  integrity sha512-yarm046UgUFIBoxqnBan2+BEgaO9KZCrLzsIsmALiQvpfW92K1lHurSawl5W6SR7wCYBnNn7CPvPE/BHFdy4YA==
+"@sentry/minimal@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.11.0.tgz#806d5512658370e40827b3e3663061db708fff33"
+  integrity sha512-XkZ7qrdlGp4IM/gjGxf1Q575yIbl5RvPbg+WFeekpo16Ufvzx37Mr8c2xsZaWosISVyE6eyFpooORjUlzy8EDw==
   dependencies:
-    "@sentry/hub" "6.10.0"
-    "@sentry/types" "6.10.0"
+    "@sentry/hub" "6.11.0"
+    "@sentry/types" "6.11.0"
     tslib "^1.9.3"
 
-"@sentry/node@^6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.10.0.tgz#d91a6877f3447d7349a7f343a1fcadc319002c09"
-  integrity sha512-buGmOjsTnxebHSfa3r/rhpjDk8xmrILG4xslTgV1C2JpbUtf96QnYNNydfsfAGcZrLWO0gid/wigxsx1fdXT8A==
+"@sentry/node@^6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/node/-/node-6.11.0.tgz#62614c18af779373a12311f2fb57a8dde278425a"
+  integrity sha512-vbk+V/n7ZIFD8rHPYy03t/gIG5V7LGdjU4qJxVDgNZzticfWPnd2sLgle/r+l60XF6SKW/epG4rnxnBcgPdWaw==
   dependencies:
-    "@sentry/core" "6.10.0"
-    "@sentry/hub" "6.10.0"
-    "@sentry/tracing" "6.10.0"
-    "@sentry/types" "6.10.0"
-    "@sentry/utils" "6.10.0"
+    "@sentry/core" "6.11.0"
+    "@sentry/hub" "6.11.0"
+    "@sentry/tracing" "6.11.0"
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
     cookie "^0.4.1"
     https-proxy-agent "^5.0.0"
     lru_map "^0.3.3"
     tslib "^1.9.3"
 
-"@sentry/tracing@6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.10.0.tgz#8dcdc28cccfad976540a3c801acb6914b9c0802e"
-  integrity sha512-jZj6Aaf8kU5wgyNXbAJHosHn8OOFdK14lgwYPb/AIDsY35g9a9ncTOqIOBp8X3KkmSR8lcBzAEyiUzCxAis2jA==
+"@sentry/tracing@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.11.0.tgz#9bd9287addea1ebc12c75b226f71c7713c0fac4f"
+  integrity sha512-9VA1/SY++WeoMQI4K6n/sYgIdRtCu9NLWqmGqu/5kbOtESYFgAt1DqSyqGCr00ZjQiC2s7tkDkTNZb38K6KytQ==
   dependencies:
-    "@sentry/hub" "6.10.0"
-    "@sentry/minimal" "6.10.0"
-    "@sentry/types" "6.10.0"
-    "@sentry/utils" "6.10.0"
+    "@sentry/hub" "6.11.0"
+    "@sentry/minimal" "6.11.0"
+    "@sentry/types" "6.11.0"
+    "@sentry/utils" "6.11.0"
     tslib "^1.9.3"
 
-"@sentry/types@6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.10.0.tgz#6b1f44e5ed4dbc2710bead24d1b32fb08daf04e1"
-  integrity sha512-M7s0JFgG7/6/yNVYoPUbxzaXDhnzyIQYRRJJKRaTD77YO4MHvi4Ke8alBWqD5fer0cPIfcSkBqa9BLdqRqcMWw==
+"@sentry/types@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.11.0.tgz#5122685478d32ddacd3a891cbcf550012df85f7c"
+  integrity sha512-gm5H9eZhL6bsIy/h3T+/Fzzz2vINhHhqd92CjHle3w7uXdTdFV98i2pDpErBGNTSNzbntqOMifYEB5ENtZAvcg==
 
-"@sentry/utils@6.10.0":
-  version "6.10.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.10.0.tgz#839a099fa0a1f0ca0893c7ce8c55ba0608c1d80f"
-  integrity sha512-F9OczOcZMFtazYVZ6LfRIe65/eOfQbiAedIKS0li4npuMz0jKYRbxrjd/U7oLiNQkPAp4/BujU4m1ZIwq6a+tg==
+"@sentry/utils@6.11.0":
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.11.0.tgz#d1dee4faf4d9c42c54bba88d5a66fb96b902a14c"
+  integrity sha512-IOvyFHcnbRQxa++jO+ZUzRvFHEJ1cZjrBIQaNVc0IYF0twUOB5PTP6joTcix38ldaLeapaPZ9LGfudbvYvxkdg==
   dependencies:
-    "@sentry/types" "6.10.0"
+    "@sentry/types" "6.11.0"
     tslib "^1.9.3"
 
 "@serialport/binding-abstract@^9.0.7":
@@ -2134,13 +2134,13 @@
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zwave-js/config@8.0.8":
-  version "8.0.8"
-  resolved "https://registry.yarnpkg.com/@zwave-js/config/-/config-8.0.8.tgz#29079ffa3136ae7168eafa272ca4eb706ebde7fe"
-  integrity sha512-i22fgpPwVj6FIJhDTUUkRURqdp3r7c/0pUfj2I6CSKYBpF4FX4Rd+CCXQn8TIXbiPbuqsTeftakVNme1vQnNaQ==
+"@zwave-js/config@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@zwave-js/config/-/config-8.1.0.tgz#5e8faf3ce2937dd407719c499c3c5aeab2daa7b6"
+  integrity sha512-kKVihObXQd0DMrrAa2iGtc6V8Z3KFQP6vOYU1kKcNjlh3UumDgidwJHUa1lHo9I8Lr5ik07YQxElcYd+SvqKew==
   dependencies:
-    "@zwave-js/core" "8.0.6"
-    "@zwave-js/shared" "8.0.3"
+    "@zwave-js/core" "8.1.0"
+    "@zwave-js/shared" "8.1.0"
     alcalzone-shared "^4.0.0"
     ansi-colors "^4.1.1"
     fs-extra "^10.0.0"
@@ -2149,13 +2149,13 @@
     semver "^7.3.5"
     winston "^3.3.3"
 
-"@zwave-js/core@8.0.6":
-  version "8.0.6"
-  resolved "https://registry.yarnpkg.com/@zwave-js/core/-/core-8.0.6.tgz#f4b44aa4abe420d68d2c972a35e764aa3e1300d0"
-  integrity sha512-vnmJe+EiwYovSUJV15RC5Ebf4EBc3e60hzWnIkJNdH7gVRFYkvkEc4jKn1kPgwAwmIrUY77YdPfhj8YT0qYn8w==
+"@zwave-js/core@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@zwave-js/core/-/core-8.1.0.tgz#8cb740bef9a7ed194e3204a22eb7b44e59427999"
+  integrity sha512-T910/BKJafMgDBuJ7a8c083Q54PflD7tptjVeE20eZ3XdLmbzFpdy11ocyxhUtovwYyvrv6Qw2PnGkQABGdoVQ==
   dependencies:
     "@alcalzone/jsonl-db" "^1.3.0"
-    "@zwave-js/shared" "8.0.3"
+    "@zwave-js/shared" "8.1.0"
     "@zwave-js/winston-daily-rotate-file" "^4.5.6-0"
     alcalzone-shared "^4.0.0"
     ansi-colors "^4.1.1"
@@ -2173,14 +2173,14 @@
   dependencies:
     moment "^2.11.2"
 
-"@zwave-js/serial@8.0.7":
-  version "8.0.7"
-  resolved "https://registry.yarnpkg.com/@zwave-js/serial/-/serial-8.0.7.tgz#2e4d4e2b78a165e83edaf23457e0d152cc294454"
-  integrity sha512-QZUCapr/hYlEYrzYb8zt+ohtUb8UzGUHQ7Um60bZnXWOUqIJMbqma230Nt8DDMmHYAi+vwpoB58kcAwGrE2Ffw==
+"@zwave-js/serial@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@zwave-js/serial/-/serial-8.1.0.tgz#76384975f97fd802d9ea221907ad38f504b265f9"
+  integrity sha512-XnsTG86kI8NDT3ACdGO9704PgQtegFHnT1Ri/xOziTfeBczFHIVElxuACkenX11ad+NjZAaCgJKFBTJHIVPyrw==
   dependencies:
-    "@sentry/node" "^6.10.0"
-    "@zwave-js/core" "8.0.6"
-    "@zwave-js/shared" "8.0.3"
+    "@sentry/node" "^6.11.0"
+    "@zwave-js/core" "8.1.0"
+    "@zwave-js/shared" "8.1.0"
     alcalzone-shared "^4.0.0"
     serialport "^9.2.0"
     winston "^3.3.3"
@@ -2193,10 +2193,10 @@
     minimist "^1.2.5"
     ws "^7.4.2"
 
-"@zwave-js/shared@8.0.3":
-  version "8.0.3"
-  resolved "https://registry.yarnpkg.com/@zwave-js/shared/-/shared-8.0.3.tgz#dea865833feec2ecefd906eb6c45c7ffc84759bf"
-  integrity sha512-WOFphykYnBbknVVqJa2fw1gj56JSvS19jUiKern5hksgMgBsi+ehXyCqzUCFpLPLC27Bo+Ps9tRqx0xAKtyLkA==
+"@zwave-js/shared@8.1.0":
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/@zwave-js/shared/-/shared-8.1.0.tgz#64699ae36a08745639acb29b3799316fa0fbda64"
+  integrity sha512-vu9hMG3aih1pkGx4VWDJy4eRiLXFCo6nyt59Rqhan7KEh/AgLF3C/pmV13VnaalcHPKsY1Yt5ARAjFNYchQZkA==
   dependencies:
     alcalzone-shared "^4.0.0"
     fs-extra "^10.0.0"
@@ -12185,19 +12185,19 @@ zip-stream@^4.1.0:
     compress-commons "^4.1.0"
     readable-stream "^3.6.0"
 
-zwave-js@^8.0.8:
-  version "8.0.8"
-  resolved "https://registry.yarnpkg.com/zwave-js/-/zwave-js-8.0.8.tgz#b9ac5b93dacdf18c7020801dc86bcca417d22f27"
-  integrity sha512-b1NcF1vLY9T2NcHT6yLmd9xwCx2Ufa9jDuAxoPWtLDeVcLWBwUoiBESM+URzK8yNCh/LPLpu/z7i022rEWRPMA==
+zwave-js@^8.1.1:
+  version "8.1.1"
+  resolved "https://registry.yarnpkg.com/zwave-js/-/zwave-js-8.1.1.tgz#3110cc0586385167c3973547f6b55a9c3164c4cb"
+  integrity sha512-LyK06qNIZZNjjhu0+L3HSNBLFD64S8t4nQyYp0+Xj3TYf/4XTB9dTjX/DVIt1f2L9OIZS1CeSvLuxlz1F+Mvng==
   dependencies:
     "@alcalzone/jsonl-db" "^1.3.0"
     "@alcalzone/pak" "^0.6.0"
-    "@sentry/integrations" "^6.10.0"
-    "@sentry/node" "^6.10.0"
-    "@zwave-js/config" "8.0.8"
-    "@zwave-js/core" "8.0.6"
-    "@zwave-js/serial" "8.0.7"
-    "@zwave-js/shared" "8.0.3"
+    "@sentry/integrations" "^6.11.0"
+    "@sentry/node" "^6.11.0"
+    "@zwave-js/config" "8.1.0"
+    "@zwave-js/core" "8.1.0"
+    "@zwave-js/serial" "8.1.0"
+    "@zwave-js/shared" "8.1.0"
     alcalzone-shared "^4.0.0"
     ansi-colors "^4.1.1"
     axios "^0.21.1"


### PR DESCRIPTION
No new features just yet, just reduces the load on our telemetry infrastructure