### PR TITLE
feat: support for S2 inclusion

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -472,6 +472,7 @@ function setupSocket(server: HttpServer) {
 		// eslint-disable-next-line @typescript-eslint/no-misused-promises
 		async (socket, data) => {
 			if (gw.zwave) {
+				if (!data.args) data.args = []
 				const result: CallAPIResult<any> & {
 					api?: string
 					originalArgs?: any[]

--- a/docs/guide/mqtt.md
+++ b/docs/guide/mqtt.md
@@ -72,6 +72,7 @@ This are the available apis:
 - `stopExclusion()`: Stops the exclusion
 - `grantSecurityClasses(requested)`: Used to resolve the S2 userCallback promise
 - `validateDSK(dsk)`: Used to resolve the S2 userCallback promise
+- `abortInclusion()`: aborts any active S2 inclusion process
 - `replaceFailedNode(nodeId, inclusionStrategy)`: Replace a failed node
 - `hardReset()`: Hard reset the controller
 - `healNode(nodeId)`: Heal a specific node

--- a/docs/guide/mqtt.md
+++ b/docs/guide/mqtt.md
@@ -66,11 +66,11 @@ This are the available apis:
 - `refreshValues(nodeId)`: Refresh all node values
 - `pingNode(nodeId)`: Ping a node
 - `pollValue(valueId)`: Polls a value from the node
-- `startInclusion()`: Starts the inclusion
+- `startInclusion(inclusionStrategy)`: Starts the inclusion
 - `startExclusion()`: Starts the exclusion
 - `stopInclusion()`: Stops the inclusion
 - `stopExclusion()`: Stops the exclusion
-- `replaceFailedNode(nodeId)`: Replace a failed node
+- `replaceFailedNode(nodeId, inclusionStrategy)`: Replace a failed node
 - `hardReset()`: Hard reset the controller
 - `healNode(nodeId)`: Heal a specific node
 - `beginHealingNetwork()`: Starts healing the network

--- a/docs/guide/mqtt.md
+++ b/docs/guide/mqtt.md
@@ -70,6 +70,8 @@ This are the available apis:
 - `startExclusion()`: Starts the exclusion
 - `stopInclusion()`: Stops the inclusion
 - `stopExclusion()`: Stops the exclusion
+- `grantSecurityClasses(requested)`: Used to resolve the S2 userCallback promise
+- `validateDSK(dsk)`: Used to resolve the S2 userCallback promise
 - `replaceFailedNode(nodeId, inclusionStrategy)`: Replace a failed node
 - `hardReset()`: Hard reset the controller
 - `healNode(nodeId)`: Heal a specific node

--- a/lib/SocketManager.ts
+++ b/lib/SocketManager.ts
@@ -23,6 +23,8 @@ export enum socketEvents {
 	api = 'API_RETURN', // api results
 	debug = 'DEBUG',
 	statistics = 'STATISTICS',
+	grantSecurityClasses = 'GRANT_SECURITY_CLASSES',
+	validateDSK = 'VALIDATE_DSK',
 }
 
 // events from client ---> server

--- a/lib/SocketManager.ts
+++ b/lib/SocketManager.ts
@@ -25,6 +25,7 @@ export enum socketEvents {
 	statistics = 'STATISTICS',
 	grantSecurityClasses = 'GRANT_SECURITY_CLASSES',
 	validateDSK = 'VALIDATE_DSK',
+	inclusionAborted = 'INCLUSION_ABORTED',
 }
 
 // events from client ---> server

--- a/lib/ZwaveClient.ts
+++ b/lib/ZwaveClient.ts
@@ -2373,6 +2373,8 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 	private _onAbortInclusion() {
 		this._dskResolve = null
 		this._grantResolve = null
+		this.sendToSocket(socketEvents.inclusionAborted, true)
+
 		logger.warn('Inclusion aborted')
 	}
 

--- a/lib/ZwaveClient.ts
+++ b/lib/ZwaveClient.ts
@@ -1098,7 +1098,9 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 
 			if (s0Key && !this.cfg.securityKeys.S0_Legacy) {
 				this.cfg.securityKeys.S0_Legacy = s0Key
-				await jsonStore.put(store.settings, this.cfg)
+				const settings = jsonStore.get(store.settings)
+				settings.zwave = this.cfg
+				await jsonStore.put(store.settings, settings)
 			} else if (process.env.NETWORK_KEY) {
 				this.cfg.securityKeys.S0_Legacy = process.env.NETWORK_KEY
 			}

--- a/lib/ZwaveClient.ts
+++ b/lib/ZwaveClient.ts
@@ -300,7 +300,7 @@ export type Z2MNode = {
 export type ZwaveConfig = {
 	port?: string
 	networkKey?: string
-	keys?: utils.DeepPartial<{
+	securityKeys?: utils.DeepPartial<{
 		S2_Unauthenticated: string
 		S2_Authenticated: string
 		S2_AccessControl: string
@@ -1094,18 +1094,19 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 				delete this.cfg.networkKey
 			}
 
-			if (s0Key && !this.cfg.keys.S0_Legacy) {
-				this.cfg.keys.S0_Legacy = s0Key
+			this.cfg.securityKeys = this.cfg.securityKeys || {}
+
+			if (s0Key && !this.cfg.securityKeys.S0_Legacy) {
+				this.cfg.securityKeys.S0_Legacy = s0Key
 				await jsonStore.put(store.settings, this.cfg)
 			} else if (process.env.NETWORK_KEY) {
-				this.cfg.keys.S0_Legacy = process.env.NETWORK_KEY
+				this.cfg.securityKeys.S0_Legacy = process.env.NETWORK_KEY
 			}
 
-			this.cfg.keys = this.cfg.keys || {}
 			zwaveOptions.securityKeys = {}
 
 			// convert security keys to buffer
-			for (const key in this.cfg.keys) {
+			for (const key in this.cfg.securityKeys) {
 				if (
 					[
 						'S2_Unauthenticated',
@@ -1113,10 +1114,10 @@ class ZwaveClient extends TypedEventEmitter<ZwaveClientEventCallbacks> {
 						'S2_AccessControl',
 						'S0_Legacy',
 					].includes(key) &&
-					this.cfg.keys[key].length === 32
+					this.cfg.securityKeys[key].length === 32
 				) {
 					zwaveOptions.securityKeys[key] = Buffer.from(
-						this.cfg.keys[key],
+						this.cfg.securityKeys[key],
 						'hex'
 					)
 				}

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -76,7 +76,6 @@
 
 				<DialogAddRemove
 					v-model="addRemoveShowDialog"
-					:nodeAddedOrRemoved="addRemoveNode"
 					:socket="socket"
 					@close="onAddRemoveClose"
 					@apiRequest="apiRequest"
@@ -136,7 +135,6 @@ export default {
 			settings: new Settings(localStorage),
 			bindedSocketEvents: {}, // keep track of the events-handlers
 			addRemoveShowDialog: false,
-			addRemoveNode: null,
 			advancedShowDialog: false,
 			actions: [
 				{
@@ -247,7 +245,6 @@ export default {
 		...mapMutations(['showSnackbar', 'setHealProgress']),
 		onAddRemoveClose() {
 			this.addRemoveShowDialog = false
-			this.addRemoveNode = null
 		},
 		async onAction(action, args = {}) {
 			if (action === 'import') {
@@ -473,9 +470,6 @@ export default {
 				)
 			}
 		},
-		onNodeAddedRemoved(node) {
-			this.addRemoveNode = node
-		},
 		bindEvent(eventName, handler) {
 			this.socket.on(socketEvents[eventName], handler)
 			this.bindedSocketEvents[eventName] = handler
@@ -488,12 +482,9 @@ export default {
 	},
 	mounted() {
 		const onApiResponse = this.onApiResponse.bind(this)
-		const onNodeAddedRemoved = this.onNodeAddedRemoved.bind(this)
 		const onHealProgress = this.setHealProgress.bind(this)
 
 		this.bindEvent('api', onApiResponse)
-		this.bindEvent('nodeRemoved', onNodeAddedRemoved)
-		this.bindEvent('nodeAdded', onNodeAddedRemoved)
 		this.bindEvent('healProgress', onHealProgress)
 	},
 	beforeDestroy() {

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -31,7 +31,7 @@
 																addRemoveShowDialog = true
 															"
 														>
-															Add/Remove Device
+															Manage nodes
 														</v-btn>
 													</v-col>
 													<v-col

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -325,10 +325,7 @@ export default {
 					}
 				}
 
-				if (
-					action === 'startInclusion' ||
-					action === 'replaceFailedNode'
-				) {
+				if (action === 'startInclusion') {
 					const secure = await this.$listeners.showConfirm(
 						'Node inclusion',
 						'Start inclusion in secure mode?',

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -476,7 +476,10 @@ export default {
 		},
 		unbindEvents() {
 			for (const event in this.bindedSocketEvents) {
-				this.socket.off(event, this.bindedSocketEvents[event])
+				this.socket.off(
+					socketEvents[event],
+					this.bindedSocketEvents[event]
+				)
 			}
 		},
 	},

--- a/src/components/ControlPanel.vue
+++ b/src/components/ControlPanel.vue
@@ -77,6 +77,7 @@
 				<DialogAddRemove
 					v-model="addRemoveShowDialog"
 					:nodeAddedOrRemoved="addRemoveNode"
+					:socket="socket"
 					@close="onAddRemoveClose"
 					@apiRequest="apiRequest"
 				/>

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -201,11 +201,12 @@
 													:items="serial_ports"
 												></v-combobox>
 											</v-col>
-											<v-row v-if="newZwave.keys">
+											<v-row v-if="newZwave.securityKeys">
 												<v-col cols="12" sm="6">
 													<v-text-field
 														v-model="
-															newZwave.keys
+															newZwave
+																.securityKeys
 																.S2_Unauthenticated
 														"
 														label="S2 Unauthenticated"
@@ -226,7 +227,8 @@
 												<v-col cols="12" sm="6">
 													<v-text-field
 														v-model="
-															newZwave.keys
+															newZwave
+																.securityKeys
 																.S2_Authenticated
 														"
 														prepend-icon="vpn_key"
@@ -247,7 +249,8 @@
 												<v-col cols="12" sm="6">
 													<v-text-field
 														v-model="
-															newZwave.keys
+															newZwave
+																.securityKeys
 																.S2_AccessControl
 														"
 														prepend-icon="vpn_key"
@@ -267,7 +270,8 @@
 												<v-col cols="12" sm="6">
 													<v-text-field
 														v-model="
-															newZwave.keys
+															newZwave
+																.securityKeys
 																.S0_Legacy
 														"
 														prepend-icon="vpn_key"
@@ -1157,7 +1161,7 @@ export default {
 				key += x.length === 2 ? x : '0' + x
 			}
 
-			this.$set(this.newZwave.keys, k, key)
+			this.$set(this.newZwave.securityKeys, k, key)
 		},
 		readFile(file, callback) {
 			const reader = new FileReader()

--- a/src/components/Settings.vue
+++ b/src/components/Settings.vue
@@ -201,22 +201,90 @@
 													:items="serial_ports"
 												></v-combobox>
 											</v-col>
-											<v-col cols="12" sm="6">
-												<v-text-field
-													v-model="
-														newZwave.networkKey
-													"
-													label="Network Key"
-													:rules="[
-														rules.validKey,
-														rules.validLength,
-													]"
-													append-outer-icon="wifi_protected_setup"
-													@click:append-outer="
-														randomKey
-													"
-												></v-text-field>
-											</v-col>
+											<v-row v-if="newZwave.keys">
+												<v-col cols="12" sm="6">
+													<v-text-field
+														v-model="
+															newZwave.keys
+																.S2_Unauthenticated
+														"
+														label="S2 Unauthenticated"
+														prepend-icon="vpn_key"
+														:rules="[
+															rules.validKey,
+															rules.validLength,
+														]"
+														persistent-hint
+														append-outer-icon="wifi_protected_setup"
+														@click:append-outer="
+															randomKey(
+																'S2_Unauthenticated'
+															)
+														"
+													></v-text-field>
+												</v-col>
+												<v-col cols="12" sm="6">
+													<v-text-field
+														v-model="
+															newZwave.keys
+																.S2_Authenticated
+														"
+														prepend-icon="vpn_key"
+														label="S2 Authenticated"
+														persistent-hint
+														:rules="[
+															rules.validKey,
+															rules.validLength,
+														]"
+														append-outer-icon="wifi_protected_setup"
+														@click:append-outer="
+															randomKey(
+																'S2_Authenticated'
+															)
+														"
+													></v-text-field>
+												</v-col>
+												<v-col cols="12" sm="6">
+													<v-text-field
+														v-model="
+															newZwave.keys
+																.S2_AccessControl
+														"
+														prepend-icon="vpn_key"
+														label="S2 Access Control"
+														:rules="[
+															rules.validKey,
+															rules.validLength,
+														]"
+														append-outer-icon="wifi_protected_setup"
+														@click:append-outer="
+															randomKey(
+																'S2_AccessControl'
+															)
+														"
+													></v-text-field>
+												</v-col>
+												<v-col cols="12" sm="6">
+													<v-text-field
+														v-model="
+															newZwave.keys
+																.S0_Legacy
+														"
+														prepend-icon="vpn_key"
+														label="S0 Legacy"
+														:rules="[
+															rules.validKey,
+															rules.validLength,
+														]"
+														append-outer-icon="wifi_protected_setup"
+														@click:append-outer="
+															randomKey(
+																'S0_Legacy'
+															)
+														"
+													></v-text-field>
+												</v-col>
+											</v-row>
 											<v-col cols="12" sm="6">
 												<v-switch
 													hint="Usage statistics allows us to gain insight how `zwave-js` is used, which manufacturers and devices are most prevalent and where to best focus our efforts in order to improve `zwave-js` the most. We do not store any personal information. Details can be found under https://zwave-js.github.io/node-zwave-js/#/getting-started/telemetry.md#usage-statistics"
@@ -1079,7 +1147,7 @@ export default {
 				return item
 			}
 		},
-		randomKey() {
+		randomKey(k) {
 			let key = ''
 
 			while (key.length < 32) {
@@ -1089,7 +1157,7 @@ export default {
 				key += x.length === 2 ? x : '0' + x
 			}
 
-			this.$set(this.newZwave, 'networkKey', key)
+			this.$set(this.newZwave.keys, k, key)
 		},
 		readFile(file, callback) {
 			const reader = new FileReader()

--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -91,6 +91,7 @@
 
 									<v-card-actions>
 										<v-btn
+											v-if="state !== 'start'"
 											color="primary"
 											@click="nextStep"
 										>
@@ -98,8 +99,8 @@
 										</v-btn>
 
 										<v-btn
-											v-if="state === 'start'"
-											text
+											v-else
+											color="error"
 											@click="stopAction"
 										>
 											Stop
@@ -129,6 +130,7 @@
 
 								<v-card-text v-if="s.key == 'inclusionMode'">
 									<v-radio-group
+										v-if="!loading"
 										v-model="s.values.inclusionMode"
 										mandatory
 									>
@@ -194,8 +196,25 @@
 										</v-radio>
 									</v-radio-group>
 
+									<v-col
+										v-else
+										class="d-flex flex-column align-center"
+									>
+										<v-icon
+											size="60"
+											color="
+												primary"
+											>all_inclusive</v-icon
+										>
+										<p class="mt-3 headline text-center">
+											Inclusion is started. Please put
+											your device in INCLUSION MODE
+										</p>
+									</v-col>
+
 									<v-card-actions>
 										<v-btn
+											v-if="!loading"
 											color="primary"
 											@click="nextStep"
 										>
@@ -203,7 +222,7 @@
 										</v-btn>
 										<v-btn
 											v-if="state === 'start'"
-											text
+											color="error"
 											@click="stopAction"
 										>
 											Stop
@@ -215,6 +234,7 @@
 									v-if="s.key == 'replaceInclusionMode'"
 								>
 									<v-radio-group
+										v-if="!loading"
 										v-model="s.values.inclusionMode"
 										mandatory
 									>
@@ -264,8 +284,25 @@
 										</v-radio>
 									</v-radio-group>
 
+									<v-col
+										v-else
+										class="d-flex flex-column align-center"
+									>
+										<v-icon
+											size="60"
+											color="
+												primary"
+											>all_inclusive</v-icon
+										>
+										<p class="mt-3 headline text-center">
+											Inclusion is started. Please put
+											your device in INCLUSION MODE
+										</p>
+									</v-col>
+
 									<v-card-actions>
 										<v-btn
+											v-if="!loading"
 											color="primary"
 											@click="nextStep"
 										>
@@ -273,7 +310,7 @@
 										</v-btn>
 										<v-btn
 											v-if="state === 'start'"
-											text
+											color="error"
 											@click="stopAction"
 										>
 											Stop
@@ -597,6 +634,7 @@ export default {
 		},
 		abortInclusion() {
 			this.aborted = true
+			this.loading = true
 			this.$emit('apiRequest', 'abortInclusion', [])
 		},
 		onGrantSecurityCC(requested) {
@@ -645,6 +683,7 @@ export default {
 			) {
 				const mode = s.values.inclusionMode
 				this.aborted = false
+				this.loading = true
 				const replaceStep = this.steps.find(
 					(s) => s.key === 'replaceFailed'
 				)

--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -2,7 +2,7 @@
 	<v-dialog v-model="value" @click:outside="$emit('close')" max-width="800px">
 		<v-card :loading="loading">
 			<v-card-title>
-				<span class="headline">Inclusion Manager</span>
+				<span class="headline">Nodes Manager</span>
 			</v-card-title>
 
 			<v-card-text>

--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -768,7 +768,7 @@ export default {
 				this.alert = null
 				this.aborted = false
 				const doneStep = this.copy(this.availableSteps.done)
-				doneStep.text = `Device found! Node ${this.nodeFound.id} added with security "${this.nodeFound.security}"`
+				doneStep.text = `Node ${this.nodeFound.id} added with security "${this.nodeFound.security}"`
 				doneStep.success = !(result && result.lowSecurity)
 				this.pushStep(doneStep)
 			}

--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -271,6 +271,7 @@
 								<v-card-text v-if="s.key == 's2Pin'">
 									<v-text-field
 										label="DSK Pin"
+										persistent-hint
 										hint="Enter the 5-digit PIN for your device and verify that the rest of digits matches the one that can be found on your device manual"
 										v-model.trim="s.values.pin"
 										:suffix="s.suffix"

--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -98,7 +98,7 @@
 										</v-btn>
 
 										<v-btn
-											v-if="state !== 'wait'"
+											v-if="state === 'start'"
 											text
 											@click="stopAction"
 										>
@@ -202,7 +202,77 @@
 											Next
 										</v-btn>
 										<v-btn
-											v-if="state !== 'wait'"
+											v-if="state === 'start'"
+											text
+											@click="stopAction"
+										>
+											Stop
+										</v-btn>
+									</v-card-actions>
+								</v-card-text>
+
+								<v-card-text
+									v-if="s.key == 'replaceInclusionMode'"
+								>
+									<v-radio-group
+										v-model="s.values.inclusionMode"
+										mandatory
+									>
+										<v-radio :value="4">
+											<template v-slot:label>
+												<div class="option">
+													<v-icon
+														color="green accent-4"
+														small
+														>enhanced_encryption</v-icon
+													>
+													<strong>S2</strong>
+													<small>S2 security</small>
+												</div>
+											</template>
+										</v-radio>
+										<v-radio :value="3">
+											<template v-slot:label>
+												<div class="option">
+													<v-icon
+														color="primary"
+														small
+														>lock</v-icon
+													>
+													<strong>S0</strong>
+													<small>S0 security</small>
+												</div>
+											</template>
+										</v-radio>
+										<v-radio :value="2">
+											<template v-slot:label>
+												<div class="option">
+													<v-icon
+														color="amber accent-4"
+														small
+														>no_encryption</v-icon
+													>
+													<strong
+														>No encryption</strong
+													>
+													<small
+														>Do not use
+														encryption</small
+													>
+												</div>
+											</template>
+										</v-radio>
+									</v-radio-group>
+
+									<v-card-actions>
+										<v-btn
+											color="primary"
+											@click="nextStep"
+										>
+											Next
+										</v-btn>
+										<v-btn
+											v-if="state === 'start'"
 											text
 											@click="stopAction"
 										>
@@ -364,6 +434,13 @@ export default {
 				},
 				inclusionMode: {
 					key: 'inclusionMode',
+					title: 'Inclusion Mode',
+					values: {
+						inclusionMode: 0, //default, smartstart no encryption
+					},
+				},
+				replaceInclusionMode: {
+					key: 'replaceInclusionMode',
 					title: 'Inclusion Mode',
 					values: {
 						inclusionMode: 0, //default, smartstart no encryption
@@ -562,7 +639,10 @@ export default {
 					this.currentAction = 'Exclusion'
 					this.sendAction('startExclusion', [])
 				}
-			} else if (s.key === 'inclusionMode') {
+			} else if (
+				s.key === 'inclusionMode' ||
+				s.key === 'replaceInclusionMode'
+			) {
 				const mode = s.values.inclusionMode
 				this.aborted = false
 				const replaceStep = this.steps.find(
@@ -614,7 +694,7 @@ export default {
 				this.loading = true
 			} else if (s.key === 'replaceFailed') {
 				this.currentAction = 'Inclusion'
-				this.pushStep('inclusionMode')
+				this.pushStep('replaceInclusionMode')
 			}
 		},
 		init() {

--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -13,7 +13,9 @@
 								:key="`${s.key}-step`"
 								:complete="currentStep > s.index"
 								:step="s.index"
-								editable
+								:editable="
+									!['s2Classes', 's2Pin'].includes(s.key)
+								"
 							>
 								{{ s.title }}
 							</v-stepper-step>

--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -251,7 +251,7 @@
 										persistent-hint
 									></v-checkbox>
 
-									<v-card-actions>
+									<v-card-actions v-if="!loading">
 										<v-btn
 											v-if="!aborted"
 											color="primary"
@@ -277,7 +277,7 @@
 									>
 									</v-text-field>
 
-									<v-card-actions>
+									<v-card-actions v-if="!loading">
 										<v-btn
 											v-if="!aborted"
 											color="primary"

--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -636,6 +636,8 @@ export default {
 			this.aborted = true
 			this.loading = true
 			this.$emit('apiRequest', 'abortInclusion', [])
+
+			this.waitTimeout = setTimeout(this.showResults, 1000)
 		},
 		onGrantSecurityCC(requested) {
 			const grantStep = this.availableSteps.s2Classes

--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -144,7 +144,7 @@
 												</div>
 											</template>
 										</v-radio>
-										<v-radio :value="1">
+										<v-radio disabled :value="1">
 											<template v-slot:label>
 												<div class="option">
 													<v-icon
@@ -152,7 +152,10 @@
 														small
 														>smart_button</v-icon
 													>
-													<strong>Smart start</strong>
+													<strong
+														>Smart start (COMING
+														SOON)</strong
+													>
 													<small
 														>S2 only. Allows
 														pre-configuring the
@@ -489,7 +492,17 @@ export default {
 				}
 			} else if (s.key === 'inclusionMode') {
 				const mode = s.values.inclusionMode
-				this.sendAction('startInclusion', [mode])
+				const replaceStep = this.steps.find(
+					(s) => s.key === 'replaceFailed'
+				)
+				if (replaceStep) {
+					this.sendAction('replaceFailedNode', [
+						replaceStep.values.replaceId,
+						mode,
+					])
+				} else {
+					this.sendAction('startInclusion', [mode])
+				}
 			} else if (s.key === 's2Classes') {
 				const values = s.values
 
@@ -523,6 +536,9 @@ export default {
 				const mode = s.values.pin
 				this.$emit('apiRequest', 'validateDSK', [mode])
 				this.loading = true
+			} else if (s.key === 'replaceFailed') {
+				this.currentAction = 'Inclusion'
+				this.pushStep('inclusionMode')
 			}
 		},
 		init() {
@@ -530,6 +546,7 @@ export default {
 			this.pushStep('action')
 			this.currentAction = null
 			this.loading = false
+			this.alert = null
 		},
 		async pushStep(step) {
 			const s =

--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -272,7 +272,7 @@
 									<v-text-field
 										label="DSK Pin"
 										hint="Enter the 5-digit PIN for your device and verify that the rest of digits matches the one that can be found on your device manual"
-										v-model.number="s.values.pin"
+										v-model.trim="s.values.pin"
 										:suffix="s.suffix"
 									>
 									</v-text-field>
@@ -379,7 +379,7 @@ export default {
 					title: 'DSK validation',
 					suffix: '',
 					values: {
-						pin: '00000',
+						pin: '',
 					},
 				},
 				replaceFailed: {

--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -425,7 +425,7 @@
 													: 'warning'
 											}}</v-icon
 										>
-										<p class="mt-3 headline">
+										<p class="mt-3 headline text-center">
 											{{ s.text }}
 										</p>
 									</v-col>
@@ -601,7 +601,9 @@ export default {
 		},
 		onNodeAdded({ node, result }) {
 			this.nodeFound = node
-			this.showResults(result)
+			if (this.loading) {
+				this.showResults(result)
+			}
 		},
 		onNodeRemoved(node) {
 			this.nodeFound = node

--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -811,7 +811,9 @@ export default {
 				this.alert = null
 				this.aborted = false
 				const doneStep = this.copy(this.availableSteps.done)
-				doneStep.text = `Node ${this.nodeFound.id} added with security "${this.nodeFound.security}"`
+				doneStep.text = `Node ${
+					this.nodeFound.id
+				} added with security "${this.nodeFound.security || 'None'}"`
 				doneStep.success = !(result && result.lowSecurity)
 				this.pushStep(doneStep)
 			}

--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -1,5 +1,10 @@
 <template>
-	<v-dialog v-model="value" @click:outside="$emit('close')" max-width="800px">
+	<v-dialog
+		v-model="value"
+		@click:outside="$emit('close')"
+		@keydown.esc="$emit('close')"
+		max-width="800px"
+	>
 		<v-card :loading="loading">
 			<v-card-title>
 				<span class="headline">Nodes Manager</span>
@@ -786,8 +791,13 @@ export default {
 		},
 		unbindEvents() {
 			for (const event in this.bindedSocketEvents) {
-				this.socket.off(event, this.bindedSocketEvents[event])
+				this.socket.off(
+					socketEvents[event],
+					this.bindedSocketEvents[event]
+				)
 			}
+
+			this.bindedSocketEvents = {}
 		},
 		showResults(result) {
 			if (this.waitTimeout) {

--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -107,11 +107,16 @@
 									</v-card-actions>
 								</v-card-text>
 								<v-card-text v-if="s.key == 'replaceFailed'">
-									<v-text-field
-										label="Node ID"
-										v-model.number="s.values.replaceId"
-									>
-									</v-text-field>
+									<v-combobox
+										label="Node"
+										v-model="s.values.replaceId"
+										:items="nodes"
+										return-object
+										chips
+										hint="Failed node to remove. Write the node Id and press enter if not present"
+										persistent-hint
+										item-text="_name"
+									></v-combobox>
 									<v-card-actions>
 										<v-btn
 											color="primary"
@@ -411,7 +416,7 @@ export default {
 		}
 	},
 	computed: {
-		...mapGetters(['appInfo', 'zwave']),
+		...mapGetters(['appInfo', 'zwave', 'nodes']),
 		timeoutMs() {
 			return this.zwave.commandsTimeout * 1000 + 800 // add small buffer
 		},
@@ -564,10 +569,13 @@ export default {
 					(s) => s.key === 'replaceFailed'
 				)
 				if (replaceStep) {
-					this.sendAction('replaceFailedNode', [
-						replaceStep.values.replaceId,
-						mode,
-					])
+					let replaceId = replaceStep.values.replaceId
+					if (typeof replaceId === 'object') {
+						replaceId = replaceId.id
+					} else {
+						replaceId = parseInt(replaceId, 10)
+					}
+					this.sendAction('replaceFailedNode', [replaceId, mode])
 				} else {
 					this.sendAction('startInclusion', [mode])
 				}

--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -489,7 +489,7 @@ export default {
 				}
 			} else if (s.key === 'inclusionMode') {
 				const mode = s.values.inclusionMode
-				this.sendAction('startExclusion', [mode])
+				this.sendAction('startInclusion', [mode])
 			} else if (s.key === 's2Classes') {
 				const values = s.values
 
@@ -529,6 +529,7 @@ export default {
 			this.steps = []
 			this.pushStep('action')
 			this.currentAction = null
+			this.loading = false
 		},
 		async pushStep(step) {
 			const s =

--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -375,6 +375,7 @@ export default {
 			this.onGrantSecurityCC.bind(this)
 		)
 		this.bindEvent('validateDSK', this.onValidateDSK.bind(this))
+		this.bindEvent('inclusionAborted', this.init.bind(this))
 	},
 	watch: {
 		value() {
@@ -445,7 +446,6 @@ export default {
 		},
 		abortInclusion() {
 			this.$emit('apiRequest', 'abortInclusion', [])
-			this.init()
 		},
 		onGrantSecurityCC(requested) {
 			const grantStep = this.availableSteps.s2Classes

--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -572,12 +572,8 @@ export default {
 				} else if (status.indexOf('stopped') > 0) {
 					// inclusion/exclusion stopped, check what happened
 					this.commandEndDate = new Date()
-					this.alert = {
-						type: 'info',
-						text: `${this.currentAction} stopped, waiting for changes…`,
-					}
 					this.state = 'wait'
-					let timeout = this.currentAction === 'Exclusion' ? 2000 : 0
+					let timeout = this.currentAction === 'Exclusion' ? 1000 : 0
 					if (this.stopped) {
 						timeout = 1000
 						this.stopped = false

--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -633,6 +633,7 @@ export default {
 			values.clientAuth = requested.clientSideAuth || undefined
 
 			this.loading = false
+			this.alert = false
 
 			this.pushStep(grantStep)
 		},
@@ -641,6 +642,8 @@ export default {
 			dskStep.suffix = dsk
 
 			this.loading = false
+			this.alert = false
+
 			this.pushStep(dskStep)
 		},
 		nextStep() {

--- a/src/components/nodes-table/NodeDetails.vue
+++ b/src/components/nodes-table/NodeDetails.vue
@@ -361,7 +361,6 @@ export default {
 					options: [
 						{ name: 'Check', action: 'isFailedNode' },
 						{ name: 'Remove', action: 'removeFailedNode' },
-						{ name: 'Replace', action: 'replaceFailedNode' },
 					],
 					icon: 'dangerous',
 					desc: 'Manage nodes that are dead and/or marked as failed with the controller',

--- a/src/components/nodes-table/nodes-table.js
+++ b/src/components/nodes-table/nodes-table.js
@@ -28,7 +28,7 @@ export default {
 				productLabel: { type: 'string', label: 'Product code' },
 				name: { type: 'string', label: 'Name' },
 				loc: { type: 'string', label: 'Location' },
-				isSecure: { type: 'boolean', label: 'Secure' },
+				security: { type: 'string', label: 'Security' },
 				supportsBeaming: { type: 'boolean', label: 'Beaming' },
 				zwavePlusVersion: {
 					type: 'string',

--- a/src/modules/ManagedItems.js
+++ b/src/modules/ManagedItems.js
@@ -37,6 +37,14 @@ export class ManagedItems {
 			this.filters === undefined
 				? this.loadSetting('filters', this.initialFilters)
 				: this.filters
+
+		// sometimes columns are updated in new releases, this allows us to show them
+		if (!this.loadSetting('cleared', false)) {
+			this._filters = this.initialFilters
+			this._columns = this.initialTableColumns
+			this.storeSetting('cleared', true)
+		}
+
 		this._selected = this.initialSelected
 
 		// fix possible inconsistance from localstorage

--- a/src/plugins/socket.js
+++ b/src/plugins/socket.js
@@ -25,4 +25,5 @@ export const socketEvents = {
 	statistics: 'STATISTICS',
 	grantSecurityClasses: 'GRANT_SECURITY_CLASSES',
 	validateDSK: 'VALIDATE_DSK',
+	inclusionAborted: 'INCLUSION_ABORTED',
 }

--- a/src/plugins/socket.js
+++ b/src/plugins/socket.js
@@ -23,4 +23,6 @@ export const socketEvents = {
 	api: 'API_RETURN', // api results
 	debug: 'DEBUG',
 	statistics: 'STATISTICS',
+	grantSecurityClasses: 'GRANT_SECURITY_CLASSES',
+	validateDSK: 'VALIDATE_DSK',
 }

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -9,7 +9,7 @@ export const state = {
     port: undefined,
     commandsTimeout: 30,
     logLevel: 'info',
-    keys: {
+    securityKeys: {
       S2_Unauthenticated: undefined,
       S2_Authenticated: undefined,
       S2_AccessControl: undefined,

--- a/src/store/mutations.js
+++ b/src/store/mutations.js
@@ -8,8 +8,13 @@ export const state = {
   zwave: {
     port: undefined,
     commandsTimeout: 30,
-    networkKey: undefined,
     logLevel: 'info',
+    keys: {
+      S2_Unauthenticated: undefined,
+      S2_Authenticated: undefined,
+      S2_AccessControl: undefined,
+      S0_Legacy: undefined,
+    },
     logToFile: false,
     serverEnabled: false,
     enableStatistics: undefined, // keep it undefined so the user dialog will show up


### PR DESCRIPTION
- Added new ZwaveClient methods `grantSecurityClasses` `validateDSK` `abortInclusion`
- Changed signature of `startInclusion` and `replaceFailedNode` methods
- New socket events
- Added `securityKeys` object setting to Zwave settings (replaces the old `networkKey` setting, old settings are automatically updated to the new format so it's back compatible)
- Added node `security` property that shows the security class used by the node (S2, S0, None, ...)
- Completely refactored Add/Remove dialog to support new inclusion steps and replace failed nodes:

https://user-images.githubusercontent.com/11502495/130618833-ec2e13b1-38c0-4d1f-a959-ab70c1e0d990.mp4

