### PR TITLE
fix(hass): set sensor device and state class for electrical energy meters

### DIFF
--- a/docs/development/intro.md
+++ b/docs/development/intro.md
@@ -2,7 +2,14 @@
 
 Developers who wants to debug the application have to open two terminals.
 
-In first terminal run `yarn dev` to start webpack-dev for front-end developing and hot reloading at <http://localhost:8092>
+First, make sure that all dependencies are installed, the build the application:
+
+```sh
+yarn install
+yarn build
+```
+
+Then, in first terminal run `yarn dev` to start webpack-dev for front-end developing and hot reloading at <http://localhost:8092>
 (**THE PORT FOR DEVELOPING IS 8092**)
 
 In the second terminal run `yarn dev:server` to start the backend server with inspect and auto restart features

--- a/docs/development/intro.md
+++ b/docs/development/intro.md
@@ -5,7 +5,7 @@ Developers who wants to debug the application have to open two terminals.
 First, make sure that all dependencies are installed, the build the application:
 
 ```sh
-yarn install
+yarn install --immutable
 yarn build
 ```
 

--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -128,15 +128,37 @@ export function meterType(
 	}
 
 	// https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/meters.json
+	// https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes
 	switch (ccSpecific.meterType) {
 		case 0x01: // electric
 			if (ccSpecific.scale == 0x00) {
+				// kWh - energy
 				cfg.props = {
 					device_class: 'energy',
+					state_class: 'total_increasing',
+				}
+			} else if (ccSpecific.scale == 0x02) {
+				// W - power
+				cfg.props = {
+					device_class: 'power',
+					state_class: 'measurement',
+				}
+			} else if (ccSpecific.scale == 0x04) {
+				// V - voltage
+				cfg.props = {
+					device_class: 'voltage',
+					state_class: 'measurement',
+				}
+			} else if (ccSpecific.scale == 0x05) {
+				// A - current
+				cfg.props = {
+					device_class: 'current',
+					state_class: 'measurement',
 				}
 			} else {
 				cfg.props = {
 					device_class: 'power',
+					state_class: 'measurement',
 				}
 			}
 			break

--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -130,8 +130,14 @@ export function meterType(
 	// https://github.com/zwave-js/node-zwave-js/blob/master/packages/config/config/meters.json
 	switch (ccSpecific.meterType) {
 		case 0x01: // electric
-			cfg.props = {
-				device_class: 'power',
+			if (ccSpecific.scale == 0x00) {
+				cfg.props = {
+					device_class: 'energy',
+				}
+			} else {
+				cfg.props = {
+					device_class: 'power',
+				}
 			}
 			break
 		case 0x02: // gas


### PR DESCRIPTION
**This is work in progress, do not merge**

_I have just started to navigate the code base, so not sure if I'm even changing things in the right place. I haven't been able to test this yet as I don't have an easy to verify this. Ideally I'd be able to test it by simulating a device before pushing to my real z-wave network. @robertsLando how would you test this in software?_

This change changes the `device_class` for electrical meters (kWh, V, A meters) from `power` to `energy`, `voltage` and `current` respectively based on home assistant's [Sensor Entity documentation](https://developers.home-assistant.io/docs/core/entity/sensor/#available-device-classes).

The proposed change also sets the `state_class` property for these sensor entities in accordance to the documentation linked above.

Things left to do:

- [ ] actually test this change
- [ ] add `state_class` to other sensor entities (e.g. humidity, temperature, illuminance, etc.)

