### PR TITLE
chore(docker): use cosign to sign the container images

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -12,6 +12,8 @@ jobs:
   build-push:
     permissions:
       packages: write
+      id-token: write
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -76,6 +78,13 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
+
+      - uses: sigstore/cosign-installer@v1.2.1
+
+      - name: Sign the images
+        run: cosign sign ${{ steps.docker_meta.outputs.tags }}
+        env:
+          COSIGN_EXPERIMENTAL: 1
 
       - name: Move cache
         run: |


### PR DESCRIPTION
long time, no PRs (sorry, busy few months)
I wrote a blog post on what+why for this https://www.appvia.io/blog/tutorial-keyless-sign-and-verify-your-container-images :)