### PR TITLE
chore(docker): use in built docker gha caching for build

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -56,28 +56,13 @@ jobs:
             org.opencontainers.image.url=https://zwave-js.github.io/zwavejs2mqtt/#/
             maintainer=robertsLando
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: buildx-${{ steps.ref-sanitized.outputs.result }}-${{ github.sha }}
-          restore-keys: |
-            buildx-${{ steps.ref-sanitized.outputs.result }}-${{ github.sha }}
-            buildx-${{ steps.ref-sanitized.outputs.result }}
-            buildx-
-
       - name: build+push
         uses: docker/build-push-action@v2
         with:
           platforms: linux/arm64,linux/amd64,linux/arm/v6,linux/arm/v7
           file: docker/Dockerfile
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}
-
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -41,27 +41,12 @@ jobs:
             org.opencontainers.image.url=https://zwave-js.github.io/zwavejs2mqtt/#/
             maintainer=robertsLando
 
-      - name: Cache Docker layers
-        uses: actions/cache@v2
-        with:
-          path: /tmp/.buildx-cache
-          key: buildx-${{ steps.ref-sanitized.outputs.result }}-${{ github.sha }}
-          restore-keys: |
-            buildx-${{ steps.ref-sanitized.outputs.result }}-${{ github.sha }}
-            buildx-${{ steps.ref-sanitized.outputs.result }}
-            buildx-
-
       - name: Buildx build
         uses: docker/build-push-action@v2
         with:
           platforms: ${{ matrix.platform }}
           file: docker/Dockerfile
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
           push: false
           tags: ${{ steps.docker_meta.outputs.tags }}
-
-      - name: Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache


### PR DESCRIPTION
caching is probably less relevant really for this now we're not waiting on ozw to compile, and with zwjs is changing so much, we probably never benefit from the cache, so you could remove this entirely but this might at least simplify the steps in the meantime