### PR TITLE
feat: allow SSL key to be specified via env var

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -139,7 +139,7 @@ export async function startServer(host: string, port: number | string) {
 	setupLogging(settings)
 
 	if (process.env.HTTPS) {
-		logger.info('HTTPS is enabled. Loading cert and keys from store...')
+		logger.info('HTTPS is enabled. Loading cert and keys')
 		const { cert, key } = await loadCertKey()
 		server = createHttpsServer(
 			{
@@ -226,8 +226,9 @@ async function loadCertKey(): Promise<{
 	cert: Buffer
 	key: Buffer
 }> {
-	const certFile = utils.joinPath(storeDir, 'cert.pem')
-	const keyFile = utils.joinPath(storeDir, 'key.pem')
+	const certFile =
+		process.env.SSL_CERTIFICATE || utils.joinPath(storeDir, 'cert.pem')
+	const keyFile = process.env.SSL_KEY || utils.joinPath(storeDir, 'key.pem')
 
 	let key: Buffer
 	let cert: Buffer
@@ -251,8 +252,14 @@ async function loadCertKey(): Promise<{
 		key = result.serviceKey
 		cert = result.certificate
 
-		await fs.writeFile(keyFile, result.serviceKey)
-		await fs.writeFile(certFile, result.certificate)
+		await fs.writeFile(
+			utils.joinPath(storeDir, 'key.pem'),
+			result.serviceKey
+		)
+		await fs.writeFile(
+			utils.joinPath(storeDir, 'cert.pem'),
+			result.certificate
+		)
 		logger.info('New cert and key created')
 	}
 

--- a/docs/guide/env-vars.md
+++ b/docs/guide/env-vars.md
@@ -10,8 +10,8 @@ This is the list of the supported environment variables:
   - `KEY_S2_AccessControl`
 - HTTPS:
 	- `HTTPS`: Enable https
-	- `SSL_CERTIFICATE`: Absolute path to SSL certificate (for Docker, ensure this is the path as it appears within the container)
-	- `SSL_KEY`: Absolute path to SSL key (for Docker, ensure this is the path as it appears within the container)
+	- `SSL_CERTIFICATE` (optional): Absolute path to SSL certificate (for Docker, ensure this is the path as it appears within the container)
+	- `SSL_KEY` (optional): Absolute path to SSL key (for Docker, ensure this is the path as it appears within the container)
 - `SESSION_SECRET`: Used as secret for session. If not provided the default one is used
 - `USE_SECURE_COOKIE`: Set the cookie [secure](https://github.com/expressjs/session#cookiesecure) option.
 - `PORT`: The port to listen to for incoming requests. Default is `8091`

--- a/docs/guide/env-vars.md
+++ b/docs/guide/env-vars.md
@@ -8,7 +8,10 @@ This is the list of the supported environment variables:
   - `KEY_S2_Unauthenticated`
   - `KEY_S2_Authenticated`
   - `KEY_S2_AccessControl`
-- `HTTPS`: Enable https
+- HTTPS:
+	- `HTTPS`: Enable https
+	- `SSL_CERTIFICATE`: Absolute path to SSL certificate (for Docker, ensure this is the path as it appears within the container)
+	- `SSL_KEY`: Absolute path to SSL key (for Docker, ensure this is the path as it appears within the container)
 - `SESSION_SECRET`: Used as secret for session. If not provided the default one is used
 - `USE_SECURE_COOKIE`: Set the cookie [secure](https://github.com/expressjs/session#cookiesecure) option.
 - `PORT`: The port to listen to for incoming requests. Default is `8091`


### PR DESCRIPTION
This PR allows a SSL cert and key to be defined by an environment variable. Fully tested on my end.