### PR TITLE
chore(docker): fix typo in docker-compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       # Instead, use the /dev/serial/by-id/X serial device for your Z-Wave stick.
       - '/dev/serial/by-id/insert_stick_reference_here:/dev/zwave'
     volumes:
-      - zwave-config::/usr/src/app/store
+      - zwave-config:/usr/src/app/store
     ports:
       - '8091:8091' # port for web interface
       - '3000:3000' # port for Z-Wave JS websocket server


### PR DESCRIPTION
typo: one colon too much in the mapping of the named volume.