### PR TITLE
chore: add test branch release workflow

### DIFF
--- a/.github/workflows/docker-release-test.yml
+++ b/.github/workflows/docker-release-test.yml
@@ -1,9 +1,9 @@
-name: Docker Test Release
+name: Docker Release - Test
 
 on:
   push:
     branches:
-      - test-release
+      - test
 
 jobs:
   build-push:
@@ -41,15 +41,14 @@ jobs:
             org.opencontainers.image.authors=Daniel Lando <daniel.sorridi@gmail.com>
             org.opencontainers.image.url=https://zwave-js.github.io/zwavejs2mqtt/#/
             maintainer=robertsLando
-      - run: echo ${{ steps.docker_meta.outputs.tags }}
 
-      # - name: build+push
-      #   uses: docker/build-push-action@v2
-      #   with:
-      #     platforms: linux/arm64,linux/amd64,linux/arm/v6,linux/arm/v7
-      #     file: docker/Dockerfile
-      #     cache-from: type=gha
-      #     cache-to: type=gha,mode=max
-      #     push: true
-      #     tags: ${{ steps.docker_meta.outputs.tags }}
-      #     labels: ${{ steps.docker_meta.outputs.labels }}
+      - name: build+push
+        uses: docker/build-push-action@v2
+        with:
+          platforms: linux/arm64,linux/amd64,linux/arm/v6,linux/arm/v7
+          file: docker/Dockerfile
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          push: true
+          tags: ${{ steps.docker_meta.outputs.tags }}
+          labels: ${{ steps.docker_meta.outputs.labels }}

--- a/.github/workflows/docker-release-test.yml
+++ b/.github/workflows/docker-release-test.yml
@@ -1,4 +1,4 @@
-name: Docker Release
+name: Docker Test Release
 
 on:
   push:
@@ -41,7 +41,7 @@ jobs:
             org.opencontainers.image.authors=Daniel Lando <daniel.sorridi@gmail.com>
             org.opencontainers.image.url=https://zwave-js.github.io/zwavejs2mqtt/#/
             maintainer=robertsLando
-      - run: echo ${ steps.docker_meta.outputs.tags }
+      - run: echo ${{ steps.docker_meta.outputs.tags }}
 
       # - name: build+push
       #   uses: docker/build-push-action@v2

--- a/.github/workflows/docker-release-test.yml
+++ b/.github/workflows/docker-release-test.yml
@@ -3,10 +3,7 @@ name: Docker Release
 on:
   push:
     branches:
-      - master
-  release:
-    types:
-      - created
+      - test-release
 
 jobs:
   build-push:
@@ -33,29 +30,26 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - id: docker_meta
-        uses: crazy-max/ghaction-docker-meta@v1
+        uses: docker/metadata-action@v3
         with:
           images: |
             ghcr.io/zwave-js/zwavejs2mqtt
             zwavejs/zwavejs2mqtt
-          tag-sha: true
-          tag-latest: true
-          tag-semver: |
-            {{version}}
           label-custom: |
             org.opencontainers.image.vendor=zwave-js
             org.opencontainers.image.documentation=https://zwave-js.github.io/zwavejs2mqtt/#/
             org.opencontainers.image.authors=Daniel Lando <daniel.sorridi@gmail.com>
             org.opencontainers.image.url=https://zwave-js.github.io/zwavejs2mqtt/#/
             maintainer=robertsLando
+      - run: echo ${ steps.docker_meta.outputs.tags }
 
-      - name: build+push
-        uses: docker/build-push-action@v2
-        with:
-          platforms: linux/arm64,linux/amd64,linux/arm/v6,linux/arm/v7
-          file: docker/Dockerfile
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          push: true
-          tags: ${{ steps.docker_meta.outputs.tags }}
-          labels: ${{ steps.docker_meta.outputs.labels }}
+      # - name: build+push
+      #   uses: docker/build-push-action@v2
+      #   with:
+      #     platforms: linux/arm64,linux/amd64,linux/arm/v6,linux/arm/v7
+      #     file: docker/Dockerfile
+      #     cache-from: type=gha
+      #     cache-to: type=gha,mode=max
+      #     push: true
+      #     tags: ${{ steps.docker_meta.outputs.tags }}
+      #     labels: ${{ steps.docker_meta.outputs.labels }}


### PR DESCRIPTION
A new workflow has been created to create test releases with `test` tag every time there is a push to `test` branch