### PR TITLE
fix(hass): barrier State needs value_template

### DIFF
--- a/hass/configurations.ts
+++ b/hass/configurations.ts
@@ -141,6 +141,7 @@ const configurations: Record<HassDeviceKey, HassDevice> = {
 			state_topic: true,
 			command_topic: true,
 			position_template: '{{ value_json.value }}',
+			value_template: '{{ value_json.value }}',
 			device_class: 'garage',
 			payload_open: 255,
 			payload_close: 0,


### PR DESCRIPTION
I believe this fixes https://github.com/zwave-js/zwavejs2mqtt/issues/1786

`barrier_state` needs a `value_template`, otherwise the `state_*` attributes won't work on JSON payloads.

In my HA logs I was seeing:

```
2022-01-07 13:29:14 WARNING (MainThread) [homeassistant.components.mqtt.cover] Payload is not supported (e.g. open, closed, opening, closing, stopped): {"time":1641576755633,"value":255}
```

I narrowed this down to my Nortek NGD00Z-4 Garage Door Controller.

Payloads coming from it look like this:

```
{"time":1641576755633,"value":255}
```

Here's the current MQTT Discovery Payload:

```
position_topic: zwave/Garage_Door_Opener/102/0/currentState
state_topic: zwave/Garage_Door_Opener/102/0/currentState
command_topic: zwave/Garage_Door_Opener/102/0/targetState/set
position_template: '{{ value_json.value }}'
device_class: garage
payload_open: 255
payload_close: 0
payload_stop: 253
state_open: 255
state_opening: 254
state_closed: 0
state_closing: 252
device:
  identifiers:
    - zwavejs2mqtt_0xfa18eef5_node22
  manufacturer: Nortek Security & Control LLC
  model: Garage Door Controller (NGD00Z-4)
  name: Garage Door Opener
  sw_version: '2.0'
name: Garage Door Opener barrier_state
unique_id: zwavejs2mqtt_0xfa18eef5_22-102-0-currentState
platform: mqtt
```

As you can see, `value_template` is missing, but that's needed for the `state_`s.

https://www.home-assistant.io/integrations/cover.mqtt/#value_template

Once added, no longer see the `WARNING`s and the state is shown in HA properly:

![image](https://user-images.githubusercontent.com/1004649/148590950-8ba5135a-3539-48a7-b625-fd72d00e9639.png)

Tested via: Docker
Zwavejs2Mqtt version: 6.2.0
Z-Wave JS version: 8.9.1