### PR TITLE
override log file location with env variable

### DIFF
--- a/lib/ZwaveClient.ts
+++ b/lib/ZwaveClient.ts
@@ -207,7 +207,9 @@ export type SensorTypeScale = {
 
 export type AllowedApis = typeof allowedApis[number]
 
-const ZWAVEJS_LOG_FILE = utils.joinPath(storeDir, 'zwavejs_%DATE%.log')
+const logDir = process.env.ZWAVEJS_LOG_DIR || storeDir
+
+const ZWAVEJS_LOG_FILE = utils.joinPath(logDir, 'zwavejs_%DATE%.log')
 
 export type Z2MValueIdState = {
 	text: string


### PR DESCRIPTION
This change allows the ZwaveJS log file location to be specified via `env` variable.

In particular, this will allow me to capture debug logs without worrying about overburdening the SD card in my Raspberry Pi (e.g., by specifying that the log directory is on a ramdisk).

~~~~~
ZWAVEJS_LOG_DIR=/ramdisk/logs/ yarn start
~~~~~

~~~~~
ubuntu@ubuntu:~/code/zwavejs2mqtt$ ls -la /ramdisk/logs/
total 676
drwxr-xr-x 2 ubuntu ubuntu    120 Jan 11 22:20 .
drwxrwxrwt 3 root   root       60 Jan 11 21:56 ..
-rw-rw-r-- 1 ubuntu ubuntu    345 Jan 11 21:57 .74e8bf9102fc26c30b78508c03bea080e82a4c85-audit.json
-rw-rw-r-- 1 ubuntu ubuntu    343 Jan 11 22:20 .cb59bdd4852b814af40a852fdd5376ce2eee1720-audit.json
-rw-rw-r-- 1 ubuntu ubuntu 680929 Jan 11 23:13 zwavejs_2022-01-11.log
lrwxrwxrwx 1 ubuntu ubuntu     22 Jan 11 22:20 zwavejs_current.log -> zwavejs_2022-01-11.log
~~~~~