### PR TITLE
fix(ui): initialize darkMode at startup

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -844,6 +844,8 @@ export default {
 			this.hideTopbar = true
 		}
 
+		this.$vuetify.theme.dark = this.darkMode
+
 		this.changeThemeColor()
 
 		this.$store.subscribe((mutation) => {


### PR DESCRIPTION
Dark mode was not initialized to the stored value at startup

Fixes https://github.com/zwave-js/zwavejs2mqtt/pull/2317#issuecomment-1076825090

