### PR TITLE
fix(ui): hint to on-screen keyboards that DSK pin is numeric

### DIFF
--- a/src/components/dialogs/DialogAddRemove.vue
+++ b/src/components/dialogs/DialogAddRemove.vue
@@ -502,6 +502,7 @@
 										class="mb-2"
 										persistent-hint
 										hint="Enter the 5-digit PIN for your device and verify that the rest of digits matches the one that can be found on your device manual"
+										inputmode="numeric"
 										v-model.trim="s.values.pin"
 										:suffix="
 											$vuetify.breakpoint.xsOnly


### PR DESCRIPTION
This will pop a digit-first keyboard instead of a letter-first one.