### PR TITLE
Test for git command in shell, avoid errors

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -140,12 +140,7 @@ export function num2hex(num: number): string {
  */
 export function getVersion(): string {
 	if (!VERSION) {
-		let revision = ''
-		try {
-			revision = execSync('git rev-parse --short HEAD').toString().trim()
-		} catch (error) {
-			// git not installed
-		}
+		const revision = execSync('command -v git || exit 0; git rev-parse --short HEAD').toString().trim()
 		VERSION = `${version}${revision ? '.' + revision : ''}`
 	}
 


### PR DESCRIPTION
Even though `execSync` is wrapped in a try...catch it will still output error messages in docker console.

This will introduce a check for the git command in the shell, if it doesn't exist, then `exit 0` else run the git command. This avoids throwing and catching errors and keeps the logs clean. 