### PR TITLE
fix: avoid showing git error on startup

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -140,13 +140,13 @@ export function num2hex(num: number): string {
  */
 export function getVersion(): string {
 	if (!VERSION) {
-		let revision = ''
 		try {
-			revision = execSync('git rev-parse --short HEAD').toString().trim()
-		} catch (error) {
-			// git not installed
+			const shellCmd = 'command -v git || exit 0; git rev-parse --short HEAD'
+			const revision = execSync(shellCmd).toString().trim()
+			VERSION = `${version}${revision ? '.' + revision : ''}`
+		} catch {
+			VERSION = version
 		}
-		VERSION = `${version}${revision ? '.' + revision : ''}`
 	}
 
 	return VERSION

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -141,7 +141,8 @@ export function num2hex(num: number): string {
 export function getVersion(): string {
 	if (!VERSION) {
 		try {
-			const shellCmd = 'command -v git || exit 0; git rev-parse --short HEAD'
+			const shellCmd =
+				'command -v git || exit 0; git rev-parse --short HEAD'
 			const revision = execSync(shellCmd).toString().trim()
 			VERSION = `${version}${revision ? '.' + revision : ''}`
 		} catch {


### PR DESCRIPTION
Even though `execSync` is wrapped in a try...catch it will still output error messages in docker console.

This will introduce a check for the git command in the shell, if it doesn't exist, then `exit 0` else run the git command. This avoids throwing and catching errors and keeps the logs clean. 