### PR TITLE
Add git to docker container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -56,7 +56,8 @@ RUN apk add --no-cache \
     libgcc \	
     libusb \	
     tzdata \	
-    eudev	
+    eudev \
+    git
 
 
 # Copy files from previous build stage	


### PR DESCRIPTION
Fixes (non-fatal) startup error `/bin/sh: git: not found`