### PR TITLE
Identifying the serial device ID

### DIFF
--- a/docs/getting-started/quick-start.md
+++ b/docs/getting-started/quick-start.md
@@ -12,6 +12,8 @@ If you are using Home Assistant, the UI can be added to Lovelace so that it can 
 
 The easiest way to run ZWavejs2Mqtt is by using docker:
 
+[x_serial-device_question.txt](https://github.com/zwave-js/zwavejs2mqtt/files/8965706/x_serial-device_question.txt)
+
 ```bash
 # Using volumes as persistence
 docker run --rm -it -p 8091:8091 -p 3000:3000 --device=/dev/serial/by-id/insert_stick_reference_here:/dev/zwave \


### PR DESCRIPTION
Which command allows me do I identify the /dev/serial/by-id/X serial device for my Z-Wave stick?

 I assume it's not the vendor/product ID as shown with ``lsusb``.

ubuntu@ubuntu:~$ lsusb -v

Bus 001 Device 006: ID 0658:0200 Sigma Designs, Inc. Aeotec Z-Stick Gen5 (ZW090) - UZB
Couldn't open device, some information will be missing
Device Descriptor:
  bLength                18
  bDescriptorType         1
  bcdUSB               2.00
  bDeviceClass            2 Communications
  bDeviceSubClass         0
  bDeviceProtocol         0
  bMaxPacketSize0         8
  idVendor           0x0658 Sigma Designs, Inc.
  idProduct          0x0200 Aeotec Z-Stick Gen5 (ZW090) - UZB
  bcdDevice            0.00
  iManufacturer           0
  iProduct                0
  iSerial                 0


Could you provide an example for how to formulate the  command accordingly: 
```bash
# Using volumes as persistence
docker run --rm -it -p 8091:8091 -p 3000:3000 --device=/dev/serial/by-id/<which expression is to be inserted here?>:/dev/zwave \
--mount source=zwavejs2mqtt,target=/usr/src/app/store zwavejs/zwavejs2mqtt:latest