### PR TITLE
docs: recommend loglevel "debug" for Z-Wave logs

### DIFF
--- a/docs/troubleshooting/generating-logs.md
+++ b/docs/troubleshooting/generating-logs.md
@@ -20,7 +20,7 @@ ZWavejs2Mqtt logger can be configured in `General` section, enable `Log enabled`
 > [!NOTE]
 > Driver logs are required for all issues that are not purely a UI issue (for which an Application Log would instead be submitted).
 
-Driver logger can be configured in `Z-Wave` section, enable `Log enabled` switch and `Log To File` and set `Log Level` to `Silly`
+Driver logger can be configured in `Z-Wave` section, enable `Log enabled` switch and `Log To File` and set `Log Level` to `Debug`
 
 > Log file name: `zwavejs_<date>.log`
 


### PR DESCRIPTION
I've just added the first `"silly"` level logs to the driver, but they are generally not necessary and would clutter the logs.
We should recommend users to use `"debug"` instead.